### PR TITLE
[Docs]: Improve README with new OpenGL features and workflow diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,38 +2,97 @@
 
 ## Current State - Work in Progress
 
-- **Graphics API**: Currently supports only OpenGL 3.3
+### gamecoe has been recently tested with OpenGL 3.0-4.6 on Linux (Arch) and worked fine.
+### If you find any bugs, please open an issue or contact games@nircoe.com
+
+- **Graphics API**: OpenGL 3.0-4.6 with version-gated features, default version is 4.6.
+    - **Set specific version**: Add the following in your CMake files before fetching gamecoe (example for version 3.3):
+        ```cmake
+        set(GAMECOE_GRAPHICS_VERSION_MAJOR 3)
+        set(GAMECOE_GRAPHICS_VERSION_MINOR 3)
+        ```
+    - **DSA (Direct State Access)** for OpenGL 4.5+ - Stateless buffer operations (`#if GAMECOE_HAS_DSA`)
+    - **UBO (Uniform Buffer Object)** for OpenGL 3.1+ - Efficient uniform data sharing (`#if GAMECOE_HAS_UBO`)
 - **Rendering**: Basic Shape rendering support (only triangle, rectangle and box at the moment)
-- **Full Engine Structure**: Game->Scene->GameObject->Component workflow
-- **GameObject/Component Life Cycle**: 
-initialize->begin->activate->update+render (repeat once a frame while active)->deactivate
-- **Scene Life Cycle**: load->activate->update+render (repeat once a frame while active)->deactivate->unload
-- **Multi Active Scene Support**: Want to build a bigger world with more than 1 active Scene at a time? Want to make the pause menu a separated Scene so your code will be more organized? gamecoe supports it!
-- **Components**: Currently our built-in Components: Transform, Renderer, ShapeRenderer, Camera
-- **logcoe**: Feel free to use our in-house tool [logcoe](https://github.com/nircoe/logcoe) as your logger during development, logcoe comes built-in with gamecoe!
-```cpp
-logcoe::debug("Player got 1 coin!");
-logcoe::error("Enemy has negative HP!");
+- **Multi Active Scene Support**: Want to build a bigger world with more than 1 active Scene at a time? 
+                                  Want to make the pause menu a separated Scene so your code will be more organized? 
+                                  gamecoe supports it!
+- **gamecoe structure**: gamecoe holds several namespaces
+    - **gamecoe**: The main namespace, built out of a few modules -
+        - **gamecoe/core**: `Game`, `Scene`, `Window` classes
+        - **gamecoe/entity**: `GameObject`, `Component`, `Transform`, `Camera`, `Renderer`, `ShapeRenderer` classes
+        - **gamecoe/graphics**: Mostly internal for gamecoe or for power user usage -
+                                `Shader`, `GraphicsBuffer`, `VertexArray` classes
+                                (`Texture` class implemented but not yet integrated into a Component)
+        - **gamecoe/utils**: Mostly internal for gamecoe
+    - **timecoe**: Track the time between frames
+        ```cpp
+        #include <timecoe.hpp>
+        float deltaTime = timecoe::deltaTime();
+        ```
+    - **colorcoe**: Use one of 140 built-in colors from the colorcoe:: namespace, 
+                    or a custom color of your own with the gamecoe::Color class!
+        ```cpp
+        #include <colorcoe.hpp>
+        auto green = colorcoe::green();
+        gamecoe::Color myColor(108, 92, 236, 98);
+        ```
+    - **inputcoe**: Full basic keyboard and mouse input tracking, want to know if a key/button just got clicked? 
+                    if it's being held down? what is the position of the mouse? 
+                    you can find this functionality and more in the inputcoe:: namespace!
+        ```cpp
+        #include <inputcoe.hpp>
+        if (inputcoe::pressed(inputcoe::Key::Space)) { /* do something */ }
+        auto mousePosition = inputcoe::mousePosition();
+        if (inputcoe::released(inputcoe::MouseButton::Left)) { /* do something */ }
+        ```
+- **gamecoe toolkit**: Use a variety of our in-house tools for better game development experience with gamecoe. 
+                       All are optional, to avoid bloatware.
+    - **logcoe**: Feel free to use our in-house tool [logcoe](https://github.com/nircoe/logcoe) as your logger during development, 
+                  logcoe comes built-in with gamecoe!
+        Just add `set(GAMECOE_USE_LOGCOE ON)` in your CMake files before fetching gamecoe, and you are good to go!
+        ```cpp
+        logcoe::debug("Player got 1 coin!");
+        logcoe::error("Enemy has negative HP!");
+        ```
+    - **soundcoe**: Feel free to use our in-house tool [soundcoe](https://github.com/nircoe/soundcoe) for your game sound management, 
+                    soundcoe comes built-in with gamecoe!
+        Just add `set(GAMECOE_USE_SOUNDCOE ON)` in your CMake files before fetching gamecoe, and you are good to go!
+        ```cpp
+        soundcoe::playMusic("boss_fight.wav");
+        soundcoe::playSound("hit.mp3");
+        ```
+
+## gamecoe Workflow
+
+- **Engine Structure**: `Game` → `Scene` → `GameObject` → `Component` classes workflow
+
+### GameObject/Component Lifecycle
 ```
-- **soundcoe**: Feel free use our in-house tool [soundcoe](https://github.com/nircoe/soundcoe) for your game sound management, soundcoe comes built-in with gamecoe!
-```cpp
-soundcoe::playMusic("boss_fight.wav");
-soundcoe::playSound("hit.mp3");
+    initialize()              Called when GameObject/Component is created
+        ↓
+    begin()                   Called at the beginning of Scene activation
+        ↓
+    activate() ←────────╮     Called when GameObject/Component is activated
+        ↓               │
+        ├─→ update() ←╮ │     Called every frame while active
+        ├─→ render() ─╯ │     Called every frame if GameObject has Renderer, or Component is a Renderer
+        ↓               │
+    deactivate() ───────╯     Called when GameObject/Component is deactivated
 ```
-- **timecoe**: Track the time between frames: 
-```cpp
-float deltaTime = timecoe::deltaTime();
+
+### Scene Lifecycle
 ```
-- **colorcoe**: Use one of 140 built-in colors from the colorcoe:: namespace, or a custom color of your own with the gamecoe::Color class!
-```cpp
-auto green = colorcoe::green();
-gamecoe::Color myColor(108, 92, 236, 98);
-```
-- **inputcoe**: Full basic keyboard and mouse input tracking, want to know if a key/button just got clicked? if it's being held down? what is the position of the mouse? you can find this functionality and more in the inputcoe:: namespace!
-```cpp
-if (inputcoe::pressed(inputcoe::Key::Space)) { /* do something */ }
-auto mousePosition = inputcoe::mousePosition();
-if (inputcoe::released(inputcoe::MouseButton::Left)) { /* do something */ }
+    load() ←───────────────╮  Called when Scene is loaded
+        ↓                  │
+    activate() ←────────╮  │  Called when Scene is activated
+        ↓               │  │
+        ├─→ update() ←╮ │  │  Called every frame while active
+        ├─→ render() ─╯ │  │  Called every frame while active
+        ↓               │  │
+    deactivate() ───────╯  │  Called when Scene is deactivated
+        ↓                  │
+    unload() ──────────────╯  Called when Scene is unloaded
 ```
 
 ## Build Requirements
@@ -100,7 +159,6 @@ gencoe component Monster -n Enemies
 
 - **Collider**: Collider Component for GameObjects collision detection and handling
 - **More Basic Shapes**: Circle, Sphere and more
-- **Support for Modern OpenGL**: Introduce support for OpenGL4.6 features
 - **Batch Rendering**: Introduce batch rendering system for better performance
 - **SpriteRenderer**: New Renderer Component for Sprite rendering
 - **datacoe**: Integrate [datacoe](https://github.com/nircoe/datacoe) for save/load data management system with optional encryption


### PR DESCRIPTION
- Document DSA (Direct State Access) for OpenGL 4.5+
- Document UBO (Uniform Buffer Objects) for OpenGL 3.1+
- Add CMake configuration examples for setting OpenGL version
- Reorganize namespace structure documentation
- Add visual lifecycle diagrams for GameObject/Component and Scene
- Clarify gamecoe toolkit (logcoe, soundcoe) with CMake setup instructions
- Improve overall README organization and clarity