### PR TITLE
[Feature]: Add frustum culling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     - **DSA (Direct State Access)** for OpenGL 4.5+ - Stateless buffer operations (`#if GAMECOE_HAS_DSA`)
     - **UBO (Uniform Buffer Object)** for OpenGL 3.1+ - Efficient uniform data sharing (`#if GAMECOE_HAS_UBO`)
     - **Shader Preprocessing**: gamecoe auto-injects `#version` and `#define` macros into your shaders
-- **Rendering**: Basic Shape rendering support (only triangle, rectangle, box, circle and sphere at the moment)
+- **Rendering**: Basic Shape rendering support (only triangle, rectangle, box, circle and sphere at the moment) with Frustum Culling
 - **Multi Active Scene Support**: Want to build a bigger world with more than 1 active Scene at a time? 
                                   Want to make the pause menu a separated Scene so your code will be more organized? 
                                   gamecoe supports it!

--- a/include/gamecoe/entity/camera.hpp
+++ b/include/gamecoe/entity/camera.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <gamecoe/entity/component.hpp>
+#include <gamecoe/utils/shape.hpp>
+#include <gamecoe/utils/frustum.hpp>
 #include <gamecoe_config.hpp>
 #include <utility>
 #include <glm/glm.hpp>
@@ -13,28 +15,10 @@
 
 namespace gamecoe
 {
+    class Transform;
+    
     class Camera : public Component<Camera>
     {
-    public:
-        struct Plane
-        {
-            // The normal vector to the plane
-            glm::vec3 m_normal;
-            // A point on the plane
-            glm::vec3 m_point;
-        };
-
-        struct Frustum
-        {
-            Plane m_topFace;
-            Plane m_bottomFace;
-            Plane m_rightFace;
-            Plane m_leftFace;
-            Plane m_nearFace;
-            Plane m_farFace;
-        };
-
-    private:
         float m_fov;
         float m_nearPlane;
         float m_farPlane;
@@ -92,5 +76,8 @@ namespace gamecoe
         const glm::mat4 &projectionMatrix() const;
 
         const Frustum &frustum() const;
+
+        // Returns if a 2D object is facing the Camera
+        bool facing(const Transform &transform) const;
     };
 } // namespace gamecoe

--- a/include/gamecoe/entity/camera.hpp
+++ b/include/gamecoe/entity/camera.hpp
@@ -15,19 +15,44 @@ namespace gamecoe
 {
     class Camera : public Component<Camera>
     {
+    public:
+        struct Plane
+        {
+            // The normal vector to the plane
+            glm::vec3 m_normal;
+            // A point on the plane
+            glm::vec3 m_point;
+        };
+
+        struct Frustum
+        {
+            Plane m_topFace;
+            Plane m_bottomFace;
+            Plane m_rightFace;
+            Plane m_leftFace;
+            Plane m_nearFace;
+            Plane m_farFace;
+        };
+
+    private:
         float m_fov;
         float m_nearPlane;
         float m_farPlane;
         float m_orthographicHeight;
 
         bool m_perspective;
-        mutable bool m_projectionCached;
 
+        mutable bool m_projectionCached;
         mutable glm::mat4 m_projectionMatrix;
+
+        mutable bool m_frustumCached;
+        mutable Frustum m_frustum;
 
 #if GAMECOE_HAS_UBO
         std::optional<GraphicsBuffer> m_uniformBuffer;
 #endif
+
+        void calculateFrustum() const;
 
     public:
         static constexpr const char* TYPE_NAME = "Camera";
@@ -57,6 +82,7 @@ namespace gamecoe
         float fov() const;
         float nearPlane() const;
         float farPlane() const;
+        // Returns a pair of floats - first the near plane and second the far plane
         std::pair<float, float> planes() const;
 
         bool perspective() const;
@@ -64,5 +90,7 @@ namespace gamecoe
 
         glm::mat4 viewMatrix() const;
         const glm::mat4 &projectionMatrix() const;
+
+        const Frustum &frustum() const;
     };
 } // namespace gamecoe

--- a/include/gamecoe/entity/renderer/renderer.hpp
+++ b/include/gamecoe/entity/renderer/renderer.hpp
@@ -8,6 +8,10 @@ namespace gamecoe
     {
     protected:
         std::int8_t m_layer;
+        mutable bool m_visible;
+
+        virtual bool visible() const = 0;
+        virtual void renderImpl() const = 0;
 
     public:
         static constexpr const char* TYPE_NAME = "Renderer";
@@ -19,7 +23,7 @@ namespace gamecoe
         Renderer& operator=(Renderer&&) = delete;
         virtual ~Renderer();
 
-        virtual void render() const = 0;
+        void render() const;
 
         void setLayer(std::int8_t layer = 0);
         std::int8_t layer() const;

--- a/include/gamecoe/entity/renderer/shape_renderer.hpp
+++ b/include/gamecoe/entity/renderer/shape_renderer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <gamecoe/entity/renderer/renderer.hpp>
+#include <gamecoe/utils/shape.hpp>
 #include <gamecoe/graphics/vertex_array.hpp>
 #include <gamecoe/graphics/shader.hpp>
 #include <gamecoe_config.hpp>
@@ -11,18 +12,9 @@
 
 namespace gamecoe
 {
-    enum class Shape
-    {
-        Triangle,
-        Rectangle,
-        Box,
-        Circle,
-        Sphere,
-        // TODO: Support more primitive shapes
-    };
-
     class ShapeRenderer : public Renderer
     {
+    private:
         static std::atomic<std::uint32_t> s_counter;
         static std::optional<Shader> s_shapeShader;
         static std::optional<Shader> s_circleShader;
@@ -32,9 +24,12 @@ namespace gamecoe
         Color m_color;
         const VertexArray &m_vertexArray;
     
-        std::optional<gamecoe::Shader> &shapeToShader(gamecoe::Shape shape) const;
+        std::optional<Shader> &shapeToShader(Shape shape) const;
 
         ShapeRenderer(GameObject &owner, Shape shape, const Color &color, std::int8_t layer = 0);
+
+        virtual bool visible() const override;
+        virtual void renderImpl() const override;
 
     public:
         ShapeRenderer(const ShapeRenderer&) = delete;
@@ -48,7 +43,6 @@ namespace gamecoe
         virtual void activate() override { m_active = true; }
         virtual void deactivate() override { m_active = false; }
         virtual void update() override {}
-        virtual void render() const override;
 
         Shape shape() const;
         Color color() const;

--- a/include/gamecoe/entity/transform.hpp
+++ b/include/gamecoe/entity/transform.hpp
@@ -129,23 +129,26 @@ namespace gamecoe
         // Rotates around the z-axis in local space (2D)
         void rotateAround(float angle);
 
-        // Returns the local forward direction vector
+        // Returns the normalized local forward direction vector
         glm::vec3 forward() const;
-        // Returns the local right direction vector
+        // Returns the normalized local right direction vector
         glm::vec3 right() const;
-        // Returns the local up direction vector
+        // Returns the normalized local up direction vector
         glm::vec3 up() const;
 
-        // Returns the world forward direction vector
+        // Returns the normalized world forward direction vector
         glm::vec3 worldForward() const;
-        // Returns the world right direction vector  
+        // Returns the normalized world right direction vector  
         glm::vec3 worldRight() const;
-        // Returns the world up direction vector
+        // Returns the normalized world up direction vector
         glm::vec3 worldUp() const;
 
         // Rotates Transform to look at target (world space coordinates)
         void lookAt(const glm::vec3 &target, const glm::vec3 &up = glm::vec3(0.0f, 1.0f, 0.0f));
         // Rotates Transform to look at target (world space 2D coordinates)
         void lookAt(const glm::vec2 &target);
+
+        // Returns if the model matrix require update
+        bool modelChanged() const;
     };
 } // namespace gamecoe

--- a/include/gamecoe/utils/frustum.hpp
+++ b/include/gamecoe/utils/frustum.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <gamecoe/utils/shape.hpp>
+#include <glm/glm.hpp>
+
+namespace gamecoe
+{
+    class Transform;
+
+    struct Frustum
+    {
+        struct Plane
+        {
+            // The normal vector to the plane
+            glm::vec3 m_normal;
+            // A point on the plane
+            glm::vec3 m_point;
+        };
+
+        Plane m_topFace;
+        Plane m_bottomFace;
+        Plane m_rightFace;
+        Plane m_leftFace;
+        Plane m_nearFace;
+        Plane m_farFace;
+
+        bool contains(const Transform &transform, Shape shape) const;
+    };
+} // namespace gamecoe

--- a/include/gamecoe/utils/shape.hpp
+++ b/include/gamecoe/utils/shape.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace gamecoe
+{
+    enum class Shape
+    {
+        Triangle,
+        Rectangle,
+        Box,
+        Circle,
+        Sphere,
+        // TODO: Support more primitive shapes
+    };
+} // namespace gamecoe

--- a/src/gamecoe/entity/camera.cpp
+++ b/src/gamecoe/entity/camera.cpp
@@ -1,5 +1,6 @@
 #include <gamecoe/entity/camera.hpp>
 #include <gamecoe/entity/game_object.hpp>
+#include <gamecoe/entity/transform.hpp>
 #include <gamecoe/core/game.hpp>
 #include <gamecoe/core/window.hpp>
 #include <gamecoe/utils/error_handler.hpp>
@@ -188,7 +189,7 @@ namespace gamecoe
         return m_projectionMatrix;
     }
 
-    const Camera::Frustum &Camera::frustum() const
+    const Frustum &Camera::frustum() const
     {
         if (!m_frustumCached || m_owner.transform().modelChanged())
         {
@@ -197,5 +198,16 @@ namespace gamecoe
         }
 
         return m_frustum;
+    }
+
+    bool Camera::facing(const Transform &transform) const
+    {
+        auto shapeNormal = transform.worldForward();
+        auto shapePosition = transform.worldPosition();
+        auto cameraPosition = m_owner.transform().worldPosition();
+        auto toCamera = glm::normalize(cameraPosition - shapePosition);
+
+        float facingDot = glm::dot(shapeNormal, toCamera);
+        return std::abs(facingDot) > 0.01f; // around 90 degrees
     }
 } // namespace gamecoe

--- a/src/gamecoe/entity/camera.cpp
+++ b/src/gamecoe/entity/camera.cpp
@@ -4,16 +4,50 @@
 #include <gamecoe/core/window.hpp>
 #include <gamecoe/utils/error_handler.hpp>
 #include <gamecoe/utils/consts.hpp>
+#include <cmath>
 
 namespace gamecoe
 {
+    void Camera::calculateFrustum() const
+    {
+        const auto &transform = m_owner.transform();
+
+        const auto position = transform.worldPosition();
+        const auto forward = transform.worldForward();
+        const auto right = transform.worldRight();
+        const auto up = transform.worldUp();
+
+        const float aspectRatio = m_owner.game().mainWindow().aspectRatio();
+        const float halfVSide = m_farPlane * std::tanf(glm::radians(m_fov) * 0.5f);
+        const float halfHSide = halfVSide * aspectRatio;
+        const auto forwardFar = m_farPlane * forward;
+
+        m_frustum.m_topFace.m_normal = m_perspective ? glm::normalize(glm::cross(right, forwardFar - (halfVSide * up))) : -up;
+        m_frustum.m_topFace.m_point = m_perspective ? position : position + (halfVSide * up);
+        m_frustum.m_bottomFace.m_normal = m_perspective ? glm::normalize(glm::cross(forwardFar + (halfVSide * up), right)) : up;
+        m_frustum.m_bottomFace.m_point = m_perspective ? position : position - (halfVSide * up);
+
+        m_frustum.m_rightFace.m_normal = m_perspective ? glm::normalize(glm::cross(forwardFar - (halfHSide * right), up)) : -right;
+        m_frustum.m_rightFace.m_point = m_perspective ? position : position + (halfHSide * right);
+        m_frustum.m_leftFace.m_normal = m_perspective ? glm::normalize(glm::cross(up, forwardFar + (halfHSide * right))) : right;
+        m_frustum.m_leftFace.m_point = m_perspective ? position : position - (halfHSide * right);
+
+        m_frustum.m_nearFace.m_normal = forward;
+        m_frustum.m_nearFace.m_point = position + (m_nearPlane * forward);
+        m_frustum.m_farFace.m_normal = -forward;
+        m_frustum.m_farFace.m_point = position + forwardFar;
+    }
+
     Camera::Camera(GameObject &owner) : Component(owner), 
                                         m_fov(45.0f),
                                         m_nearPlane(0.1f),
                                         m_farPlane(100.0f),
                                         m_orthographicHeight(-1.0f),
                                         m_perspective(true),
-                                        m_projectionCached(false)
+                                        m_projectionCached(false),
+                                        m_projectionMatrix(),
+                                        m_frustumCached(false),
+                                        m_frustum()
     {
 #if GAMECOE_HAS_UBO
         m_uniformBuffer.emplace(UniformBuffer(constcoe::CAMERA_UBO_BINDING_POINT));
@@ -53,7 +87,7 @@ namespace gamecoe
             detail::invalidArgument("Camera::setFov(): FOV must be between 0 and 180 degrees");
 
         m_fov = fov;
-        m_projectionCached = false;
+        m_projectionCached = m_frustumCached = false;
     }
 
     void Camera::setNearPlane(float nearPlane) 
@@ -65,7 +99,7 @@ namespace gamecoe
                                ") must be greater than the near plane (" + std::to_string(nearPlane) + ")");
 
         m_nearPlane = nearPlane; 
-        m_projectionCached = false;
+        m_projectionCached = m_frustumCached = false;
     }
 
     void Camera::setFarPlane(float farPlane) 
@@ -77,7 +111,7 @@ namespace gamecoe
                                ") must be greater than the near plane (" + std::to_string(m_nearPlane) + ")");
 
         m_farPlane = farPlane;
-        m_projectionCached = false;
+        m_projectionCached = m_frustumCached = false;
     }
 
     void Camera::setPlanes(float nearPlane, float farPlane)
@@ -89,7 +123,7 @@ namespace gamecoe
 
         m_nearPlane = nearPlane;
         m_farPlane = farPlane;
-        m_projectionCached = false;
+        m_projectionCached = m_frustumCached = false;
     }
 
     void Camera::setPerspectiveMode() 
@@ -97,7 +131,7 @@ namespace gamecoe
         if (m_perspective) return;
 
         m_orthographicHeight = -1.0f;
-        m_projectionCached = false;
+        m_projectionCached = m_frustumCached = false;
         m_perspective = true;
     }
 
@@ -109,7 +143,7 @@ namespace gamecoe
             detail::invalidArgument("Camera::setOrthographicMode(): Orthographic size must be positive");
 
         m_orthographicHeight = orthographicSize;
-        m_projectionCached = false;
+        m_projectionCached = m_frustumCached = false;
         m_perspective = false;
     }
 
@@ -152,5 +186,16 @@ namespace gamecoe
         }
 
         return m_projectionMatrix;
+    }
+
+    const Camera::Frustum &Camera::frustum() const
+    {
+        if (!m_frustumCached || m_owner.transform().modelChanged())
+        {
+            calculateFrustum();
+            m_frustumCached = true;
+        }
+
+        return m_frustum;
     }
 } // namespace gamecoe

--- a/src/gamecoe/entity/renderer/renderer.cpp
+++ b/src/gamecoe/entity/renderer/renderer.cpp
@@ -6,7 +6,7 @@
 
 namespace gamecoe
 {
-    Renderer::Renderer(GameObject &owner, std::int8_t layer) : Component<Renderer>(owner), m_layer(layer) 
+    Renderer::Renderer(GameObject &owner, std::int8_t layer) : Component<Renderer>(owner), m_layer(layer), m_visible(true)
     { 
         m_owner.scene().addRenderer(m_layer, &m_owner);
     }
@@ -15,6 +15,11 @@ namespace gamecoe
     {
         try { m_owner.scene().removeRenderer(m_layer ,m_owner.id()); }
         catch (const std::exception &e) { detail::throwError("Renderer::~Renderer(): " + std::string(e.what())); }
+    }
+
+    void Renderer::render() const
+    {
+        if (visible()) renderImpl();
     }
 
     void Renderer::setLayer(std::int8_t layer) 

--- a/src/gamecoe/entity/renderer/shape_renderer.cpp
+++ b/src/gamecoe/entity/renderer/shape_renderer.cpp
@@ -5,6 +5,7 @@
 #include <gamecoe/core/game.hpp>
 #include <gamecoe/utils/paths.hpp>
 #include <gamecoe/utils/consts.hpp>
+#include <gamecoe/utils/frustum.hpp>
 #include <cassert>
 #include <optional>
 #include <utility>
@@ -56,7 +57,7 @@ namespace gamecoe
     std::optional<Shader> ShapeRenderer::s_circleShader = std::nullopt;
     std::optional<Shader> ShapeRenderer::s_sphereShader = std::nullopt;
 
-    std::optional<gamecoe::Shader> &ShapeRenderer::shapeToShader(gamecoe::Shape shape) const
+    std::optional<Shader> &ShapeRenderer::shapeToShader(Shape shape) const
     {
         switch (shape)
         {
@@ -81,19 +82,26 @@ namespace gamecoe
         ++s_counter;
     }
 
-    ShapeRenderer::~ShapeRenderer()
+    bool ShapeRenderer::visible() const
     {
-        --s_counter;
-        if (s_counter == 0)
+        auto &camera = m_owner.game().mainCamera();
+        auto &transform = m_owner.transform();
+
+        // Camera or Object moved, need to calculate visiblity
+        if (transform.modelChanged() || camera.owner().transform().modelChanged())
         {
-            s_shapeShader.reset();
-            s_circleShader.reset();
-            s_sphereShader.reset();
-            VertexArray::destroyShapeVAs();
+            transform.modelMatrix(); // Updates the cached Model Matrix and the .modelChanged() result for next time
+            m_visible = camera.frustum().contains(transform, m_shape);
+
+            bool is2D = m_shape == Shape::Triangle || m_shape == Shape::Rectangle || m_shape == Shape::Circle;
+            if (is2D)
+                m_visible = m_visible && camera.facing(transform);
         }
+
+        return m_visible;
     }
 
-    void ShapeRenderer::render() const
+    void ShapeRenderer::renderImpl() const
     {
         if (!m_active) return;
         
@@ -111,12 +119,12 @@ namespace gamecoe
         shader->use();
         
 #if !GAMECOE_HAS_UBO
-        auto &camera = owner().game().mainCamera();
+        auto &camera = m_owner.game().mainCamera();
         shader->set("view", camera.viewMatrix());
         shader->set("projection", camera.projectionMatrix());
         shader->set("cameraPosition", camera.owner().transform().worldPosition());
 #endif
-        auto &transform = owner().transform();
+        auto &transform = m_owner.transform();
         shader->set("model", transform.modelMatrix());
         shader->set("color", m_color.normalized());
         if(m_shape == Shape::Sphere)
@@ -130,6 +138,18 @@ namespace gamecoe
         else
             glDrawArrays(GL_TRIANGLES, 0, m_vertexArray.vertexCount());
 #endif
+    }
+
+    ShapeRenderer::~ShapeRenderer()
+    {
+        --s_counter;
+        if (s_counter == 0)
+        {
+            s_shapeShader.reset();
+            s_circleShader.reset();
+            s_sphereShader.reset();
+            VertexArray::destroyShapeVAs();
+        }
     }
 
     Shape ShapeRenderer::shape() const { return m_shape; }

--- a/src/gamecoe/entity/transform.cpp
+++ b/src/gamecoe/entity/transform.cpp
@@ -184,8 +184,8 @@ namespace gamecoe
     {
         if (!m_owner.hasParent()) return setPosition(position);
 
-        const auto &parentModel = m_owner.parent()->get().transform().modelMatrix();
-        auto localPos = glm::inverse(parentModel) * glm::vec4(position, 1.0f);
+        const auto &parentInverseModel = m_owner.parent()->get().transform().inverseModelMatrix();
+        auto localPos = parentInverseModel * glm::vec4(position, 1.0f);
         
         setPosition({ localPos.x, localPos.y, localPos.z });
     }

--- a/src/gamecoe/entity/transform.cpp
+++ b/src/gamecoe/entity/transform.cpp
@@ -265,32 +265,32 @@ namespace gamecoe
 
     glm::vec3 Transform::forward() const
     {
-        return m_rotation * s_forwardVector;
+        return glm::normalize(m_rotation * s_forwardVector);
     }
 
     glm::vec3 Transform::right() const
     {
-        return m_rotation * s_rightVector;
+        return glm::normalize(m_rotation * s_rightVector);
     }
 
     glm::vec3 Transform::up() const
     {
-        return m_rotation * s_upVector;
+        return glm::normalize(m_rotation * s_upVector);
     }
 
     glm::vec3 Transform::worldForward() const
     {
-        return worldRotation() * s_forwardVector;
+        return glm::normalize(worldRotation() * s_forwardVector);
     }
 
     glm::vec3 Transform::worldRight() const
     {
-        return worldRotation() * s_rightVector;
+        return glm::normalize(worldRotation() * s_rightVector);
     }
 
     glm::vec3 Transform::worldUp() const
     {
-        return worldRotation() * s_upVector;
+        return glm::normalize(worldRotation() * s_upVector);
     }
 
     void Transform::lookAt(const glm::vec3 &target, const glm::vec3 &up)
@@ -302,5 +302,10 @@ namespace gamecoe
     void Transform::lookAt(const glm::vec2 &target)
     {
         lookAt({ target.x, target.y, 0.0f });
+    }
+
+    bool Transform::modelChanged() const
+    {
+        return m_modelChanged;
     }
 } // namespace gamecoe

--- a/src/gamecoe/utils/frustum.cpp
+++ b/src/gamecoe/utils/frustum.cpp
@@ -1,0 +1,42 @@
+#include <gamecoe/utils/frustum.hpp>
+#include <gamecoe/entity/transform.hpp>
+
+namespace gamecoe
+{
+    bool Frustum::contains(const Transform &transform, Shape shape) const
+    {
+        // Conservative frustum culling using bounding spheres for all shapes
+        // False positives (rendering slightly off screen objects) are acceptable
+
+        auto center = transform.worldPosition();
+        auto scale = transform.worldScale();
+
+        float radius;
+        switch (shape)
+        {
+        case Shape::Triangle:
+        case Shape::Rectangle:
+        case Shape::Circle:
+            radius = glm::max(scale.x, scale.y);
+            break;
+        case Shape::Box:
+            radius = glm::length(scale) * 0.5f;
+            break;
+        case Shape::Sphere:
+        default:
+            radius = glm::max(glm::max(scale.x, scale.y), scale.z);
+            break;
+        }
+
+        Plane planes[6] = { m_topFace, m_bottomFace, m_rightFace, m_leftFace, m_nearFace, m_farFace };
+
+        for(auto &plane : planes)
+        {
+            float distance = glm::dot(plane.m_normal, center - plane.m_point);
+            if (distance < -radius)
+                return false;
+        }
+
+        return true;
+    }
+} // namespace gamecoe


### PR DESCRIPTION
- Add Plane and Frustum structs with view volume extraction
- Implement conservative bounding sphere culling for all shapes
- Add Template Method pattern to Renderer (visible/renderImpl)
- Add 2D shape edge-on culling with facing check
- Extract Shape enum to utils/ for future Collider reuse
- Optimize with matrix caching and dirty flag tracking
- Update README.md