### PR TITLE
[Feature]: Implement 2D collision detection

### DIFF
--- a/assets/shaders/circle_renderer.frag
+++ b/assets/shaders/circle_renderer.frag
@@ -9,7 +9,7 @@ uniform vec4 color;
 
 float circleAlpha(vec3 lPos)
 {
-    const float RADIUS = 1.0;
+    const float RADIUS = 0.5;
 
     float dist = length(lPos);
     float edgeWidth = fwidth(dist);

--- a/assets/shaders/circle_renderer.vert
+++ b/assets/shaders/circle_renderer.vert
@@ -22,9 +22,6 @@ uniform vec3 cameraPosition;
 
 void main()
 {
-    const float SCALE_MULTIPLIER = 2.05; // Quad is -0.5 to 0.5, scale to radius 1.0, I'm using 2.05 for the anti-aliasing
-
-    vec3 scaledPos = aPos * SCALE_MULTIPLIER;
-    localPos = scaledPos;
-    gl_Position = projection * view * model * vec4(scaledPos, 1.0);
+    localPos = aPos;
+    gl_Position = projection * view * model * vec4(aPos, 1.0);
 }

--- a/assets/shaders/sphere_renderer.frag
+++ b/assets/shaders/sphere_renderer.frag
@@ -25,11 +25,12 @@ uniform vec3 cameraPosition;
 
 vec4 sphereHit(out vec3 normal)
 {
+    const float RADIUS = 0.5;
     vec3 rayDirection = normalize(localPos - localCamPos);
 
     // float a = dot(rayDirection, rayDirection) = 1.0;
     float b = 2.0 * dot(localCamPos, rayDirection);
-    float c = dot(localCamPos, localCamPos) - 1.0;
+    float c = dot(localCamPos, localCamPos) - (RADIUS * RADIUS);
 
     float discriminant = b * b - 4.0 * c;
 

--- a/assets/shaders/sphere_renderer.vert
+++ b/assets/shaders/sphere_renderer.vert
@@ -25,7 +25,7 @@ uniform vec3 cameraPosition;
 
 void main()
 {
-    localPos = aPos * 2.0; // Box is -0.5 to 0.5, scale to radius 1.0
+    localPos = aPos;
     localCamPos = vec3(inverseModel * vec4(cameraPosition, 1.0));
-    gl_Position = projection * view * model * vec4(localPos, 1.0);
+    gl_Position = projection * view * model * vec4(aPos, 1.0);
 }

--- a/include/gamecoe/core/game.hpp
+++ b/include/gamecoe/core/game.hpp
@@ -29,6 +29,7 @@ namespace gamecoe
         std::unordered_map<std::string, std::unique_ptr<Scene>> m_inactiveScenes;
 
         mutable std::map<std::int8_t, std::vector<std::reference_wrapper<Collider>>> m_colliders;
+        mutable std::vector<std::pair<std::int8_t, std::reference_wrapper<Collider>>> m_collidersToAdd;
         mutable std::vector<std::pair<std::int8_t, std::reference_wrapper<Collider>>> m_collidersToRemove;
 
         Color m_backgroundColor;
@@ -36,7 +37,8 @@ namespace gamecoe
         // TODO: For games with multiply windows - optional
         // std::vector<std::unique_ptr<Window>> m_additionalWindows;
 
-        void processColliderRemovals() const;
+        // Delayed additions and removals of colliders
+        void processColliderModifications() const;
 
     public:
         Game(); // Default title "gamecoe", screen size 800x600 pixels

--- a/include/gamecoe/core/game.hpp
+++ b/include/gamecoe/core/game.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <gamecoe/core/window.hpp>
+#include <gamecoe/core/scene.hpp>
+#include <gamecoe/entity/camera.hpp>
 #include <unordered_map>
 #include <map>
 #include <vector>
@@ -8,14 +11,14 @@
 #include <optional>
 #include <functional>
 #include <string>
+#include <map>
 #include <cstdint>
-#include <gamecoe/core/window.hpp>
-#include <gamecoe/core/scene.hpp>
-#include <gamecoe/entity/camera.hpp>
 #include <colorcoe.hpp>
 
 namespace gamecoe
-{    
+{
+    class Collider;
+
     class Game
     {
         std::optional<Window> m_mainWindow;
@@ -24,6 +27,8 @@ namespace gamecoe
 
         std::unordered_map<std::string, std::unique_ptr<Scene>> m_activeScenes;
         std::unordered_map<std::string, std::unique_ptr<Scene>> m_inactiveScenes;
+
+        mutable std::map<std::int8_t, std::vector<std::reference_wrapper<Collider>>> m_colliders; // need to be in Game in order to support collision detection between entities from different scenes
 
         Color m_backgroundColor;
 
@@ -50,6 +55,10 @@ namespace gamecoe
 
         std::map<std::int8_t, std::vector<std::reference_wrapper<Scene>>> getActiveSceneLayers() const;
         void setSceneLayer(const std::string &scene, std::int8_t layer);
+
+        void addCollider(Collider& collider, std::int8_t layer) const;
+        void updateColliderLayer(Collider& collider, std::int8_t oldLayer, std::int8_t newLayer) const;
+        void removeCollider(Collider& collider, std::int8_t layer) const;
 
         Camera &mainCamera();
         const Camera &mainCamera() const;

--- a/include/gamecoe/core/game.hpp
+++ b/include/gamecoe/core/game.hpp
@@ -28,12 +28,15 @@ namespace gamecoe
         std::unordered_map<std::string, std::unique_ptr<Scene>> m_activeScenes;
         std::unordered_map<std::string, std::unique_ptr<Scene>> m_inactiveScenes;
 
-        mutable std::map<std::int8_t, std::vector<std::reference_wrapper<Collider>>> m_colliders; // need to be in Game in order to support collision detection between entities from different scenes
+        mutable std::map<std::int8_t, std::vector<std::reference_wrapper<Collider>>> m_colliders;
+        mutable std::vector<std::pair<std::int8_t, std::reference_wrapper<Collider>>> m_collidersToRemove;
 
         Color m_backgroundColor;
 
         // TODO: For games with multiply windows - optional
         // std::vector<std::unique_ptr<Window>> m_additionalWindows;
+
+        void processColliderRemovals() const;
 
     public:
         Game(); // Default title "gamecoe", screen size 800x600 pixels

--- a/include/gamecoe/entity/collider/collider.hpp
+++ b/include/gamecoe/entity/collider/collider.hpp
@@ -15,16 +15,16 @@ namespace gamecoe
         std::int8_t m_layer;
         mutable std::unordered_set<std::uint32_t> m_collidedWith;
 
-        std::function<void(const Collider&)> m_onCollisionBegin;    // First frame of a collision callback
-        std::function<void(const Collider&)> m_onCollision;         // Continuous collision callback
-        std::function<void(const Collider&)> m_onCollisionEnd;      // First frame after a collision ends callback
+        std::function<void(Collider&)> m_onCollisionBegin;    // First frame of a collision callback
+        std::function<void(Collider&)> m_onCollision;         // Continuous collision callback
+        std::function<void(Collider&)> m_onCollisionEnd;      // First frame after a collision ends callback
 
     public:
         static constexpr const char* TYPE_NAME = "Collider";
 
-        Collider(GameObject &owner, const std::function<void(const Collider&)> &onCollisionBegin = nullptr, 
-                                    const std::function<void(const Collider&)> &onCollision = nullptr, 
-                                    const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+        Collider(GameObject &owner, const std::function<void(Collider&)> &onCollisionBegin = nullptr, 
+                                    const std::function<void(Collider&)> &onCollision = nullptr, 
+                                    const std::function<void(Collider&)> &onCollisionEnd = nullptr,
                                     std::int8_t layer = 0);
 
         Collider(const Collider &other) = delete;
@@ -41,16 +41,16 @@ namespace gamecoe
         virtual void update() override;
 
         // Sets callback method for the first frame of a collision
-        void setOnCollisionBegin(const std::function<void(const Collider&)> &onCollisionBegin);
+        void setOnCollisionBegin(const std::function<void(Collider&)> &onCollisionBegin);
         // Sets callback method for a continuous collision
-        void setOnCollision(const std::function<void(const Collider&)> &onCollision);
+        void setOnCollision(const std::function<void(Collider&)> &onCollision);
         // Sets callback method for the first frame after a collision ends
-        void setOnCollisionEnd(const std::function<void(const Collider&)> &onCollisionEnd);
+        void setOnCollisionEnd(const std::function<void(Collider&)> &onCollisionEnd);
 
         void setLayer(std::int8_t layer);
         std::int8_t layer() const;
 
         virtual Shape shape() const;
-        void collide(const Collider &other) const;
+        void collide(Collider &other);
     };
 } // namespace gamecoe

--- a/include/gamecoe/entity/collider/collider.hpp
+++ b/include/gamecoe/entity/collider/collider.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <gamecoe/entity/component.hpp>
+#include <functional>
+#include <unordered_set>
+#include <cstdint>
+
+namespace gamecoe
+{
+    enum class Shape;
+
+    class Collider : public Component<Collider>
+    {
+    protected: 
+        mutable std::unordered_set<std::uint32_t> m_collidedWith;
+
+        std::function<void(const Collider&)> m_onCollisionBegin;    // First frame of a collision callback
+        std::function<void(const Collider&)> m_onCollision;         // Continuous collision callback
+        std::function<void(const Collider&)> m_onCollisionEnd;      // First frame after a collision ends callback
+
+    public:
+        static constexpr const char* TYPE_NAME = "Collider";
+
+        Collider(GameObject &owner, const std::function<void(const Collider&)> &onCollisionBegin = nullptr, 
+                                    const std::function<void(const Collider&)> &onCollision = nullptr, 
+                                    const std::function<void(const Collider&)> &onCollisionEnd = nullptr);
+
+        Collider(const Collider &other) = delete;
+        Collider& operator=(const Collider &other) = delete;
+        Collider(Collider &&other) = delete;
+        Collider& operator=(Collider &&other) = delete;
+
+        virtual ~Collider() = 0;
+
+        virtual void initialize() override;
+        virtual void begin() override;
+        virtual void activate() override;
+        virtual void deactivate() override;
+        virtual void update() override;
+
+        // Sets callback method for the first frame of a collision
+        void setOnCollisionBegin(const std::function<void(const Collider&)> &onCollisionBegin);
+        // Sets callback method for a continuous collision
+        void setOnCollision(const std::function<void(const Collider&)> &onCollision);
+        // Sets callback method for the first frame after a collision ends
+        void setOnCollisionEnd(const std::function<void(const Collider&)> &onCollisionEnd);
+
+        virtual Shape shape() const;
+        void collide(const Collider &other) const;
+    };
+} // namespace gamecoe

--- a/include/gamecoe/entity/collider/collider.hpp
+++ b/include/gamecoe/entity/collider/collider.hpp
@@ -12,6 +12,7 @@ namespace gamecoe
     class Collider : public Component<Collider>
     {
     protected: 
+        std::int8_t m_layer;
         mutable std::unordered_set<std::uint32_t> m_collidedWith;
 
         std::function<void(const Collider&)> m_onCollisionBegin;    // First frame of a collision callback
@@ -23,7 +24,8 @@ namespace gamecoe
 
         Collider(GameObject &owner, const std::function<void(const Collider&)> &onCollisionBegin = nullptr, 
                                     const std::function<void(const Collider&)> &onCollision = nullptr, 
-                                    const std::function<void(const Collider&)> &onCollisionEnd = nullptr);
+                                    const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                    std::int8_t layer = 0);
 
         Collider(const Collider &other) = delete;
         Collider& operator=(const Collider &other) = delete;
@@ -44,6 +46,9 @@ namespace gamecoe
         void setOnCollision(const std::function<void(const Collider&)> &onCollision);
         // Sets callback method for the first frame after a collision ends
         void setOnCollisionEnd(const std::function<void(const Collider&)> &onCollisionEnd);
+
+        void setLayer(std::int8_t layer);
+        std::int8_t layer() const;
 
         virtual Shape shape() const;
         void collide(const Collider &other) const;

--- a/include/gamecoe/entity/collider/shape_collider.hpp
+++ b/include/gamecoe/entity/collider/shape_collider.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <gamecoe/entity/component.hpp>
+#include <gamecoe/entity/collider/collider.hpp>
+#include <gamecoe/utils/shape.hpp>
+#include <memory>
+#include <cstdint>
+
+namespace gamecoe
+{
+    class ShapeCollider : public Collider
+    {
+        Shape m_shape;
+
+        ShapeCollider(GameObject &owner, Shape shape, 
+                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr, 
+                        const std::function<void(const Collider&)> &onCollision = nullptr, 
+                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr, 
+                        std::int8_t layer = 0);
+
+    public:
+        ShapeCollider(const ShapeCollider &other) = delete;
+        ShapeCollider& operator=(const ShapeCollider &other) = delete;
+        ShapeCollider(ShapeCollider &&other) = delete;
+        ShapeCollider& operator=(ShapeCollider &&other) = delete;
+        virtual ~ShapeCollider() override;
+
+        virtual void initialize() override;
+        virtual void begin() override;
+        virtual void activate() override;
+        virtual void deactivate() override;
+        virtual void update() override;
+
+        virtual Shape shape() const override;
+
+        static std::unique_ptr<ShapeCollider> triangle(GameObject &owner,
+                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        std::int8_t layer = 0);
+        static std::unique_ptr<ShapeCollider> rectangle(GameObject &owner,
+                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        std::int8_t layer = 0);
+        static std::unique_ptr<ShapeCollider> box(GameObject &owner,
+                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        std::int8_t layer = 0);
+        static std::unique_ptr<ShapeCollider> circle(GameObject &owner,
+                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        std::int8_t layer = 0);
+        static std::unique_ptr<ShapeCollider> sphere(GameObject &owner,
+                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        std::int8_t layer = 0);
+    };
+} // namespace gamecoe

--- a/include/gamecoe/entity/collider/shape_collider.hpp
+++ b/include/gamecoe/entity/collider/shape_collider.hpp
@@ -13,9 +13,9 @@ namespace gamecoe
         Shape m_shape;
 
         ShapeCollider(GameObject &owner, Shape shape, 
-                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr, 
-                        const std::function<void(const Collider&)> &onCollision = nullptr, 
-                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr, 
+                        const std::function<void(Collider&)> &onCollisionBegin = nullptr, 
+                        const std::function<void(Collider&)> &onCollision = nullptr, 
+                        const std::function<void(Collider&)> &onCollisionEnd = nullptr, 
                         std::int8_t layer = 0);
 
     public:
@@ -34,29 +34,29 @@ namespace gamecoe
         virtual Shape shape() const override;
 
         static std::unique_ptr<ShapeCollider> triangle(GameObject &owner,
-                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionEnd = nullptr,
                                                         std::int8_t layer = 0);
         static std::unique_ptr<ShapeCollider> rectangle(GameObject &owner,
-                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionEnd = nullptr,
                                                         std::int8_t layer = 0);
         static std::unique_ptr<ShapeCollider> box(GameObject &owner,
-                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionEnd = nullptr,
                                                         std::int8_t layer = 0);
         static std::unique_ptr<ShapeCollider> circle(GameObject &owner,
-                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionEnd = nullptr,
                                                         std::int8_t layer = 0);
         static std::unique_ptr<ShapeCollider> sphere(GameObject &owner,
-                                                        const std::function<void(const Collider&)> &onCollisionBegin = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollision = nullptr,
-                                                        const std::function<void(const Collider&)> &onCollisionEnd = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionBegin = nullptr,
+                                                        const std::function<void(Collider&)> &onCollision = nullptr,
+                                                        const std::function<void(Collider&)> &onCollisionEnd = nullptr,
                                                         std::int8_t layer = 0);
     };
 } // namespace gamecoe

--- a/include/gamecoe/entity/component.hpp
+++ b/include/gamecoe/entity/component.hpp
@@ -37,7 +37,7 @@ namespace gamecoe
         Component& operator=(Component&&) = delete;
         virtual ~Component() = default;
 
-        static std::string staticType() { return Derived::TYPE_NAME; };
+        static constexpr std::string staticType() { return Derived::TYPE_NAME; };
         // Returns the component type in string
         const std::string &type() const { return staticType(); };
 

--- a/include/gamecoe/entity/game_object.hpp
+++ b/include/gamecoe/entity/game_object.hpp
@@ -50,6 +50,10 @@ namespace gamecoe
 
     public:
         GameObject(Scene &scene, const std::string &name = "", std::optional<std::reference_wrapper<GameObject>> parent = std::nullopt);
+        GameObject(const GameObject&) = delete;
+        GameObject(GameObject&&) = delete;
+        GameObject &operator=(const GameObject&) = delete;
+        GameObject &operator=(GameObject&&) = delete;
         ~GameObject();
 
         // Called only once, when initializing the GameObject

--- a/include/gamecoe/entity/game_object.hpp
+++ b/include/gamecoe/entity/game_object.hpp
@@ -130,12 +130,11 @@ namespace gamecoe
     template <std::derived_from<ComponentBase> T>
     inline void GameObject::addComponent(std::unique_ptr<T> component)
     {
-        static const std::string componentType = T::staticType();
-        if (m_components.contains(componentType))
+        if (m_components.contains(T::staticType()))
             detail::throwError("GameObject::addComponent(): The Game Object \"" + m_name + "\" already have a " + 
-                               componentType + " component");
+                               T::staticType() + " component");
         
-        if (componentType == Transform::staticType())
+        if constexpr (T::staticType() == Transform::staticType())
             detail::invalidArgument("GameObject::addComponent(): GameObject have built-in Transform Component");
         
         if constexpr (std::is_base_of_v<Renderer, T>)
@@ -144,16 +143,14 @@ namespace gamecoe
             return setRenderer(std::move(component));
         }
 
-        m_components.emplace(componentType, std::move(component));
-        setUpComponent(m_components[componentType]);
+        m_components.emplace(T::staticType(), std::move(component));
+        setUpComponent(m_components[T::staticType()]);
     }
     
     template <std::derived_from<ComponentBase> T>
     inline void GameObject::removeComponent()
     {
-        static const std::string componentType = T::staticType();
-
-        if (componentType == Transform::staticType())
+        if constexpr (T::staticType() == Transform::staticType())
             detail::invalidArgument("GameObject::removeComponent(): You cannot remove Transform from any GameObject");
         
         if constexpr (std::is_base_of_v<Renderer, T>)
@@ -162,25 +159,23 @@ namespace gamecoe
             return removeRenderer();
         }
 
-        if (!m_components.contains(componentType))
+        if (!m_components.contains(T::staticType()))
             detail::throwError("GameObject::removeComponent(): The Game Object \"" + m_name + 
-                               "\" does not have an " + componentType + " component");
+                               "\" does not have an " + T::staticType() + " component");
 
-        m_components.erase(componentType);
+        m_components.erase(T::staticType());
     }
 
     template <std::derived_from<ComponentBase> T>
     inline T &GameObject::getComponent()
     {
-        static const std::string componentType = T::staticType();
-
-        if (componentType == Transform::staticType())
+        if constexpr (T::staticType() == Transform::staticType())
         {
             logcoe::debug("GameObject::getComponent(): Returning Transform (prefer transform() for direct access)");
             return m_transform;
         }
 
-        if (std::is_base_of_v<Renderer, T>)
+        if constexpr (std::is_base_of_v<Renderer, T>)
         {
             if (!m_renderer)
                 detail::throwError("GameObject::getComponent(): The Game Object \"" + m_name + "\" does not have a Renderer");
@@ -189,10 +184,10 @@ namespace gamecoe
             return static_cast<T&>(*m_renderer);
         }
 
-        auto it = m_components.find(componentType);
+        auto it = m_components.find(T::staticType());
         if (it == m_components.end())
             detail::throwError("GameObject::getComponent(): The Game Object \"" + m_name + "\" does not have a " + 
-                                componentType + " component");
+                                T::staticType() + " component");
             
         return static_cast<T&>(*(it->second));
     }
@@ -200,15 +195,13 @@ namespace gamecoe
     template <std::derived_from<ComponentBase> T>
     inline const T &GameObject::getComponent() const
     {
-        static const std::string componentType = T::staticType();
-
-        if (componentType == Transform::staticType())
+        if constexpr (T::staticType() == Transform::staticType())
         {
             logcoe::debug("GameObject::getComponent(): Returning Transform (prefer transform() for direct access)");
             return m_transform;
         }
 
-        if (std::is_base_of_v<Renderer, T>)
+        if constexpr (std::is_base_of_v<Renderer, T>)
         {
             if (!m_renderer)
                 detail::throwError("GameObject::getComponent(): The Game Object \"" + m_name + "\" does not have a Renderer");
@@ -217,10 +210,10 @@ namespace gamecoe
             return static_cast<const T&>(*m_renderer);
         }
 
-        auto it = m_components.find(componentType);
+        auto it = m_components.find(T::staticType());
         if (it == m_components.end())
             detail::throwError("GameObject::getComponent(): The Game Object \"" + m_name + "\" does not have a " + 
-                                componentType + " component");
+                                T::staticType() + " component");
             
         return static_cast<const T&>(*(it->second));
     }
@@ -228,15 +221,13 @@ namespace gamecoe
     template <std::derived_from<ComponentBase> T>
     inline bool GameObject::hasComponent() const
     {
-        static const std::string componentType = T::staticType();
-
-        if (componentType == Transform::staticType())
+        if constexpr (T::staticType() == Transform::staticType())
             return true;
 
-        if (std::is_base_of_v<Renderer, T>)
+        if constexpr (std::is_base_of_v<Renderer, T>)
             return m_renderer != nullptr;
 
-        return m_components.contains(componentType);
+        return m_components.contains(T::staticType());
     }
 
 } // namespace gamecoe

--- a/include/gamecoe/entity/transform.hpp
+++ b/include/gamecoe/entity/transform.hpp
@@ -16,6 +16,7 @@ namespace gamecoe
         mutable glm::mat4 m_cachedModelMatrix{1.0f};
         mutable glm::mat4 m_cachedInverseModelMatrix{1.0f};
         mutable bool m_modelChanged = true;
+        mutable bool m_cachedModelValid = false;
 
         void invalidateCachedModel() const;
 
@@ -148,7 +149,9 @@ namespace gamecoe
         // Rotates Transform to look at target (world space 2D coordinates)
         void lookAt(const glm::vec2 &target);
 
-        // Returns if the model matrix require update
+        // Returns if the transform moved in the current frame
         bool modelChanged() const;
+        // Clears the modelChanged flag
+        void clearModelChanged() const;
     };
 } // namespace gamecoe

--- a/include/gamecoe/graphics/vertex_array.hpp
+++ b/include/gamecoe/graphics/vertex_array.hpp
@@ -2,6 +2,7 @@
 #include <gamecoe/graphics/graphics_buffer.hpp>
 #include <optional>
 #include <vector>
+#include <cstdint>
 
 namespace gamecoe
 {
@@ -9,7 +10,7 @@ namespace gamecoe
     {
         static std::vector<VertexArray*> s_shapeVAs;
 
-        unsigned int m_id;
+        std::uint32_t m_id;
         GraphicsBuffer m_vertexBuffer;
         std::optional<GraphicsBuffer> m_indexBuffer;
         size_t m_vertexCount;
@@ -18,7 +19,7 @@ namespace gamecoe
 
         VertexArray() = delete;
         VertexArray(const float *vertices, size_t vertexCount, size_t vertexSize,
-                    const unsigned int *indices = nullptr, size_t indexCount = 0);
+                    const std::uint32_t *indices = nullptr, size_t indexCount = 0);
         
         void setupVertexAttributes();
 

--- a/include/gamecoe/utils/collision.hpp
+++ b/include/gamecoe/utils/collision.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <gamecoe/entity/transform.hpp>
+#include <gamecoe/utils/shape.hpp>
+#include <utility>
+#include <cstdint>
+
+namespace gamecoe
+{
+    namespace collision
+    {
+        // Collision detection for ShapeCollider/ShapeCollider
+        bool detect(const Transform &t1, Shape s1, const Transform &t2, Shape s2);
+        // TODO: add overload detect methods for different Colliders
+    } // namespace collision
+} // namespace gamecoe

--- a/include/gamecoe/utils/geometry.hpp
+++ b/include/gamecoe/utils/geometry.hpp
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <glm/glm.hpp>
+
+namespace gamecoe
+{
+    namespace geometry
+    {
+        namespace triangle
+        {
+            constexpr std::array<glm::vec3, 3> vertices()
+            {
+                return 
+                {
+                    glm::vec3{-0.5f, -0.5f, 0.0f},
+                    glm::vec3{ 0.5f, -0.5f, 0.0f},
+                    glm::vec3{ 0.0f,  0.5f, 0.0f}
+                };
+            }
+
+            constexpr std::array<float, 9> verticesFlat()
+            {
+                constexpr auto verts = vertices();
+                return 
+                {
+                    verts[0].x, verts[0].y, verts[0].z,
+                    verts[1].x, verts[1].y, verts[1].z,
+                    verts[2].x, verts[2].y, verts[2].z
+                };
+            }
+
+            constexpr std::array<std::uint32_t, 3> indices()
+            {
+                return 
+                {
+                    0, 1, 2,
+                };
+            }
+        } // namespace triangle
+
+
+        namespace rectangle
+        {
+            constexpr std::array<glm::vec3, 4> vertices()
+            {
+                return 
+                {
+                    glm::vec3{-0.5f, -0.5f, 0.0f},
+                    glm::vec3{ 0.5f, -0.5f, 0.0f},
+                    glm::vec3{ 0.5f,  0.5f, 0.0f},
+                    glm::vec3{-0.5f,  0.5f, 0.0f}
+                };
+            }
+
+            constexpr std::array<float, 12> verticesFlat()
+            {
+                constexpr auto verts = vertices();
+                return 
+                {
+                    verts[0].x, verts[0].y, verts[0].z,
+                    verts[1].x, verts[1].y, verts[1].z,
+                    verts[2].x, verts[2].y, verts[2].z,
+                    verts[3].x, verts[3].y, verts[3].z
+                };
+            }
+
+            constexpr std::array<std::uint32_t, 6> indices()
+            {
+                return 
+                {
+                    0, 1, 2,
+                    2, 3, 0
+                };
+            }
+        } // namespace rectangle
+
+        namespace box
+        {
+            constexpr std::array<glm::vec3, 8> vertices()
+            {
+                return 
+                {
+                    glm::vec3{-0.5f, -0.5f,  0.5f},
+                    glm::vec3{ 0.5f, -0.5f,  0.5f},
+                    glm::vec3{ 0.5f,  0.5f,  0.5f},
+                    glm::vec3{-0.5f,  0.5f,  0.5f},
+                    glm::vec3{-0.5f, -0.5f, -0.5f},
+                    glm::vec3{ 0.5f, -0.5f, -0.5f},
+                    glm::vec3{ 0.5f,  0.5f, -0.5f},
+                    glm::vec3{-0.5f,  0.5f, -0.5f}
+                };
+            }
+
+            constexpr std::array<float, 24> verticesFlat()
+            {
+                constexpr auto verts = vertices();
+                return 
+                {
+                    verts[0].x, verts[0].y, verts[0].z,
+                    verts[1].x, verts[1].y, verts[1].z,
+                    verts[2].x, verts[2].y, verts[2].z,
+                    verts[3].x, verts[3].y, verts[3].z,
+                    verts[4].x, verts[4].y, verts[4].z,
+                    verts[5].x, verts[5].y, verts[5].z,
+                    verts[6].x, verts[6].y, verts[6].z,
+                    verts[7].x, verts[7].y, verts[7].z
+                };
+            }
+
+            constexpr std::array<std::uint32_t, 36> indices()
+            {
+                return 
+                {
+                    0, 1, 2, 2, 3, 0,
+                    4, 5, 6, 6, 7, 4,
+                    7, 3, 0, 0, 4, 7,
+                    1, 5, 6, 6, 2, 1,
+                    4, 0, 1, 1, 5, 4,
+                    3, 7, 6, 6, 2, 3
+                };
+            }
+        } // namespace box
+
+        namespace circle
+        {
+            const std::array<glm::vec3, 16>& vertices();
+        } // namespace circle
+
+        namespace sphere
+        {
+            const std::array<glm::vec3, 42>& vertices();
+        } // namespace sphere
+        
+        template<std::size_t N>
+        std::array<glm::vec3, N> transformVertices(const std::array<glm::vec3, N> &vertices, const glm::mat4 &matrix)
+        {
+            std::array<glm::vec3, N> transformed;
+            for (std::size_t i = 0; i < N; ++i)
+                transformed[i] = glm::vec3(matrix * glm::vec4(vertices[i], 1.0f));
+            
+            return transformed;
+        }
+    } // namespace geometry
+} // namespace gamecoe

--- a/include/gamecoe/utils/shape.hpp
+++ b/include/gamecoe/utils/shape.hpp
@@ -4,6 +4,7 @@ namespace gamecoe
 {
     enum class Shape
     {
+        Invalid,
         Triangle,
         Rectangle,
         Box,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,10 +12,10 @@ target_include_directories(gamecoe
 
 target_link_libraries(gamecoe
     PRIVATE
-        glm::glm-header-only
         glfw
         stb
     PUBLIC
+        glm::glm-header-only
         gamecoe_headers
         $<$<BOOL:${GAMECOE_USE_LOGCOE}>:logcoe>
         $<$<BOOL:${GAMECOE_USE_SOUNDCOE}>:soundcoe>

--- a/src/gamecoe/core/game.cpp
+++ b/src/gamecoe/core/game.cpp
@@ -262,7 +262,6 @@ namespace gamecoe
                 for (auto &scene : scenes)
                     scene.get().update();
             }
-
             m_internalScene->update();
 
             // TODO: Physics/Collision system
@@ -272,6 +271,7 @@ namespace gamecoe
                 for (auto &scene : scenes)
                     scene.get().render();
             }
+            m_mainCamera->owner().transform().clearModelChanged();
 
             soundcoe::update();
         }

--- a/src/gamecoe/core/game.cpp
+++ b/src/gamecoe/core/game.cpp
@@ -23,6 +23,25 @@
 
 namespace gamecoe
 {
+    void Game::processColliderRemovals() const
+    {
+        for (auto &[layer, collider] : m_collidersToRemove)
+        {
+            if (auto colliders = m_colliders.find(layer); colliders != m_colliders.end())
+            {
+                auto it = std::find_if(colliders->second.begin(), colliders->second.end(),
+                    [&collider](const auto &col) { return &col.get() == &collider.get(); });
+
+                if (it != colliders->second.end())
+                {
+                    colliders->second.erase(it);
+                    if (colliders->second.empty())
+                        m_colliders.erase(layer);
+                }
+            }
+        }
+    }
+
     Game::Game() : Game("gamecoe", 800, 600) { }
 
     Game::Game(const std::string &title, uint32_t width, uint32_t height, const Color &backgroundColor) :
@@ -31,6 +50,7 @@ namespace gamecoe
                     m_activeScenes(),
                     m_inactiveScenes(),
                     m_colliders(),
+                    m_collidersToRemove(),
                     m_backgroundColor(backgroundColor)
     {
         struct GarbageCollector
@@ -200,19 +220,7 @@ namespace gamecoe
 
     void Game::removeCollider(Collider& collider, std::int8_t layer) const
     {
-        if (auto colliders = m_colliders.find(layer); colliders != m_colliders.end())
-        {
-            auto it = std::find_if(colliders->second.begin(), colliders->second.end(),
-                [&collider](const auto &col) { return &col.get() == &collider; });
-
-            if (it != colliders->second.end())
-            {
-                    colliders->second.erase(it);
-                    if (colliders->second.empty())
-                        m_colliders.erase(layer);
-                    return;
-            }
-        }
+        m_collidersToRemove.push_back({ layer, std::ref(collider)});
     }
 
     Camera &Game::mainCamera()
@@ -302,6 +310,7 @@ namespace gamecoe
                         for (auto &collider2 : it2->second)
                             collider1.get().collide(collider2.get());
             }
+            processColliderRemovals();
 
             for (auto &[layer, scenes] : scenesByLayers)
             {

--- a/src/gamecoe/core/game.cpp
+++ b/src/gamecoe/core/game.cpp
@@ -23,7 +23,7 @@
 
 namespace gamecoe
 {
-    void Game::processColliderRemovals() const
+    void Game::processColliderModifications() const
     {
         for (auto &[layer, collider] : m_collidersToRemove)
         {
@@ -40,6 +40,14 @@ namespace gamecoe
                 }
             }
         }
+
+        for (auto &[layer, collider] : m_collidersToAdd)
+        {
+            m_colliders[layer].push_back(collider);
+        }
+
+        m_collidersToRemove.clear();
+        m_collidersToAdd.clear();
     }
 
     Game::Game() : Game("gamecoe", 800, 600) { }
@@ -209,7 +217,7 @@ namespace gamecoe
 
     void Game::addCollider(Collider& collider, std::int8_t layer) const
     {
-        m_colliders[layer].push_back(std::ref(collider));        
+        m_collidersToAdd.push_back({ layer, std::ref(collider) });    
     }
 
     void Game::updateColliderLayer(Collider& collider, std::int8_t oldLayer, std::int8_t newLayer) const
@@ -220,7 +228,7 @@ namespace gamecoe
 
     void Game::removeCollider(Collider& collider, std::int8_t layer) const
     {
-        m_collidersToRemove.push_back({ layer, std::ref(collider)});
+        m_collidersToRemove.push_back({ layer, std::ref(collider) });
     }
 
     Camera &Game::mainCamera()
@@ -310,7 +318,7 @@ namespace gamecoe
                         for (auto &collider2 : it2->second)
                             collider1.get().collide(collider2.get());
             }
-            processColliderRemovals();
+            processColliderModifications();
 
             for (auto &[layer, scenes] : scenesByLayers)
             {

--- a/src/gamecoe/core/game.cpp
+++ b/src/gamecoe/core/game.cpp
@@ -1,11 +1,12 @@
 #include <gamecoe/core/game.hpp>
-#include <gamecoe/core/window.hpp>
+#include <gamecoe/entity/collider/collider.hpp>
 #include <gamecoe/utils/error_handler.hpp>
 #include <gamecoe/utils/paths.hpp>
 #include <gamecoe_config.hpp>
 #include <timecoe.hpp>
 #include <inputcoe.hpp>
 #include <cassert>
+#include <algorithm>
 
 #if GAMECOE_USE_LOGCOE
 #include <logcoe.hpp>
@@ -29,6 +30,7 @@ namespace gamecoe
                     m_internalScene(std::nullopt),
                     m_activeScenes(),
                     m_inactiveScenes(),
+                    m_colliders(),
                     m_backgroundColor(backgroundColor)
     {
         struct GarbageCollector
@@ -185,6 +187,34 @@ namespace gamecoe
         detail::throwError("Game::setSceneLayer(): The Scene named \"" + scene + "\" does not exist");
     }
 
+    void Game::addCollider(Collider& collider, std::int8_t layer) const
+    {
+        m_colliders[layer].push_back(std::ref(collider));        
+    }
+
+    void Game::updateColliderLayer(Collider& collider, std::int8_t oldLayer, std::int8_t newLayer) const
+    {
+        removeCollider(collider, oldLayer);
+        addCollider(collider, newLayer);
+    }
+
+    void Game::removeCollider(Collider& collider, std::int8_t layer) const
+    {
+        if (auto colliders = m_colliders.find(layer); colliders != m_colliders.end())
+        {
+            auto it = std::find_if(colliders->second.begin(), colliders->second.end(),
+                [&collider](const auto &col) { return &col.get() == &collider; });
+
+            if (it != colliders->second.end())
+            {
+                    colliders->second.erase(it);
+                    if (colliders->second.empty())
+                        m_colliders.erase(layer);
+                    return;
+            }
+        }
+    }
+
     Camera &Game::mainCamera()
     {
         assert(m_mainCamera && "Game::mainCamera(): Main Camera should have been created in the Game constructor and not been nullptr");
@@ -264,7 +294,14 @@ namespace gamecoe
             }
             m_internalScene->update();
 
-            // TODO: Physics/Collision system
+            for (auto it1 = m_colliders.begin(); it1 != m_colliders.end(); ++it1)
+            {
+                auto it2 = it1;
+                for (++it2; it2 != m_colliders.end(); ++it2)
+                    for (auto &collider1 : it1->second)
+                        for (auto &collider2 : it2->second)
+                            collider1.get().collide(collider2.get());
+            }
 
             for (auto &[layer, scenes] : scenesByLayers)
             {

--- a/src/gamecoe/core/window.cpp
+++ b/src/gamecoe/core/window.cpp
@@ -46,7 +46,10 @@ namespace gamecoe
             detail::throwError("Window::Window(): Failed to create glfw window");
 
         if(!current) // multi-window support
+        {
             glfwMakeContextCurrent(window);
+            glfwSwapInterval(0); // TODO: maybe in the future allow the users to limit their FPS
+        }
         
         glfwSetWindowUserPointer(window, this);
 

--- a/src/gamecoe/core/window.cpp
+++ b/src/gamecoe/core/window.cpp
@@ -48,7 +48,7 @@ namespace gamecoe
         if(!current) // multi-window support
         {
             glfwMakeContextCurrent(window);
-            glfwSwapInterval(0); // TODO: maybe in the future allow the users to limit their FPS
+            //TODO: RESTORE BEFORE MERGE: glfwSwapInterval(0); // TODO: maybe in the future allow the users to limit their FPS
         }
         
         glfwSetWindowUserPointer(window, this);

--- a/src/gamecoe/entity/collider/collider.cpp
+++ b/src/gamecoe/entity/collider/collider.cpp
@@ -8,9 +8,9 @@
 namespace gamecoe
 {
     Collider::Collider(GameObject &owner,
-        const std::function<void(const Collider&)> &onCollisionBegin, 
-        const std::function<void(const Collider&)> &onCollision, 
-        const std::function<void(const Collider&)> &onCollisionEnd,
+        const std::function<void(Collider&)> &onCollisionBegin, 
+        const std::function<void(Collider&)> &onCollision, 
+        const std::function<void(Collider&)> &onCollisionEnd,
         std::int8_t layer) : Component<Collider>(owner),
         m_layer(layer),
         m_collidedWith(),
@@ -63,20 +63,20 @@ namespace gamecoe
 
     void Collider::update()
     {
-        
+
     }
 
-    void Collider::setOnCollisionBegin(const std::function<void(const Collider&)> &onCollisionBegin)
+    void Collider::setOnCollisionBegin(const std::function<void(Collider&)> &onCollisionBegin)
     {
         m_onCollisionBegin = onCollisionBegin;
     }
 
-    void Collider::setOnCollision(const std::function<void(const Collider&)> &onCollision)
+    void Collider::setOnCollision(const std::function<void(Collider&)> &onCollision)
     {
         m_onCollision = onCollision;
     }
 
-    void Collider::setOnCollisionEnd(const std::function<void(const Collider&)> &onCollisionEnd)
+    void Collider::setOnCollisionEnd(const std::function<void(Collider&)> &onCollisionEnd)
     {
         m_onCollisionEnd = onCollisionEnd;
     }
@@ -97,7 +97,7 @@ namespace gamecoe
         return Shape::Invalid;
     }
 
-    void Collider::collide(const Collider &other) const
+    void Collider::collide(Collider &other)
     {
         if (!m_active || !other.active()) return;
 

--- a/src/gamecoe/entity/collider/collider.cpp
+++ b/src/gamecoe/entity/collider/collider.cpp
@@ -61,6 +61,11 @@ namespace gamecoe
         m_owner.game().removeCollider(*this, m_layer);
     }
 
+    void Collider::update()
+    {
+        
+    }
+
     void Collider::setOnCollisionBegin(const std::function<void(const Collider&)> &onCollisionBegin)
     {
         m_onCollisionBegin = onCollisionBegin;

--- a/src/gamecoe/entity/collider/collider.cpp
+++ b/src/gamecoe/entity/collider/collider.cpp
@@ -1,0 +1,119 @@
+#include <gamecoe/entity/collider/collider.hpp>
+#include <gamecoe/entity/game_object.hpp>
+#include <gamecoe/core/scene.hpp>
+#include <gamecoe/utils/collision.hpp>
+#include <gamecoe/utils/shape.hpp>
+
+namespace gamecoe
+{
+    Collider::Collider(GameObject &owner,
+        const std::function<void(const Collider&)> &onCollisionBegin, 
+        const std::function<void(const Collider&)> &onCollision, 
+        const std::function<void(const Collider&)> &onCollisionEnd) : Component<Collider>(owner),
+        m_collidedWith(),
+        m_onCollisionBegin(onCollisionBegin), 
+        m_onCollision(onCollision), 
+        m_onCollisionEnd(onCollisionEnd)
+    { 
+        
+    }
+
+    Collider::~Collider()
+    {
+        m_onCollisionBegin = nullptr;
+        m_onCollision = nullptr;
+        m_onCollisionEnd = nullptr;
+    }
+
+    void Collider::initialize()
+    {
+
+    }
+
+    void Collider::begin()
+    {
+
+    }
+
+    void Collider::activate() 
+    {
+
+    }
+
+    void Collider::deactivate() 
+    {
+        auto id = m_owner.id();
+        for (auto otherId : m_collidedWith)
+        {
+            auto go = m_owner.scene().findGameObject(otherId);
+
+            if (go && go->get().hasComponent<Collider>())
+            {
+                auto &col = go->get().getComponent<Collider>();
+                if (m_onCollisionEnd) m_onCollisionEnd(col); // really needed? the gameobject is deactivating...
+                if (col.m_onCollisionEnd) col.m_onCollisionEnd(*this);
+                col.m_collidedWith.erase(m_owner.id());
+            }
+        }
+        m_collidedWith.clear();
+    }
+
+    void Collider::setOnCollisionBegin(const std::function<void(const Collider&)> &onCollisionBegin)
+    {
+        m_onCollisionBegin = onCollisionBegin;
+    }
+
+    void Collider::setOnCollision(const std::function<void(const Collider&)> &onCollision)
+    {
+        m_onCollision = onCollision;
+    }
+
+    void Collider::setOnCollisionEnd(const std::function<void(const Collider&)> &onCollisionEnd)
+    {
+        m_onCollisionEnd = onCollisionEnd;
+    }
+
+    Shape Collider::shape() const 
+    {
+        return Shape::Invalid;
+    }
+
+    void Collider::collide(const Collider &other) const
+    {
+        if (!m_active || !other.active()) return;
+
+        // other is a ShapeCollider
+        if (other.shape() != Shape::Invalid)
+        {
+            bool collided = collision::detect(m_owner.transform(), shape(), other.owner().transform(), other.shape());
+
+            std::uint32_t id = m_owner.id();
+            std::uint32_t otherId = other.owner().id();
+
+            if (auto it = m_collidedWith.find(otherId); it != m_collidedWith.end())
+            {
+                if (collided)
+                {
+                    if (m_onCollision) m_onCollision(other);
+                    if (other.m_onCollision) other.m_onCollision(*this);
+                    return;
+                } 
+
+                if (m_onCollisionEnd) m_onCollisionEnd(other);
+                if (other.m_onCollisionEnd) other.m_onCollisionEnd(*this);
+                m_collidedWith.erase(it);
+                other.m_collidedWith.erase(id);
+                return;
+            }
+
+            if (!collided) return;
+
+            m_collidedWith.insert(otherId);
+            other.m_collidedWith.insert(id);
+            if (m_onCollisionBegin) m_onCollisionBegin(other);
+            if (other.m_onCollisionBegin) other.m_onCollisionBegin(*this);
+            return;
+        }
+        // TODO: treat other Colliders
+    }
+} // namespace gamecoe

--- a/src/gamecoe/entity/collider/collider.cpp
+++ b/src/gamecoe/entity/collider/collider.cpp
@@ -1,5 +1,6 @@
 #include <gamecoe/entity/collider/collider.hpp>
 #include <gamecoe/entity/game_object.hpp>
+#include <gamecoe/core/game.hpp>
 #include <gamecoe/core/scene.hpp>
 #include <gamecoe/utils/collision.hpp>
 #include <gamecoe/utils/shape.hpp>
@@ -9,7 +10,9 @@ namespace gamecoe
     Collider::Collider(GameObject &owner,
         const std::function<void(const Collider&)> &onCollisionBegin, 
         const std::function<void(const Collider&)> &onCollision, 
-        const std::function<void(const Collider&)> &onCollisionEnd) : Component<Collider>(owner),
+        const std::function<void(const Collider&)> &onCollisionEnd,
+        std::int8_t layer) : Component<Collider>(owner),
+        m_layer(layer),
         m_collidedWith(),
         m_onCollisionBegin(onCollisionBegin), 
         m_onCollision(onCollision), 
@@ -37,7 +40,7 @@ namespace gamecoe
 
     void Collider::activate() 
     {
-
+        m_owner.game().addCollider(*this, m_layer);
     }
 
     void Collider::deactivate() 
@@ -50,12 +53,13 @@ namespace gamecoe
             if (go && go->get().hasComponent<Collider>())
             {
                 auto &col = go->get().getComponent<Collider>();
-                if (m_onCollisionEnd) m_onCollisionEnd(col); // really needed? the gameobject is deactivating...
+                if (m_onCollisionEnd) m_onCollisionEnd(col);
                 if (col.m_onCollisionEnd) col.m_onCollisionEnd(*this);
                 col.m_collidedWith.erase(m_owner.id());
             }
         }
         m_collidedWith.clear();
+        m_owner.game().removeCollider(*this, m_layer);
     }
 
     void Collider::setOnCollisionBegin(const std::function<void(const Collider&)> &onCollisionBegin)
@@ -73,6 +77,17 @@ namespace gamecoe
         m_onCollisionEnd = onCollisionEnd;
     }
 
+    void Collider::setLayer(std::int8_t layer)
+    {
+        m_owner.game().updateColliderLayer(*this, m_layer, layer);
+        m_layer = layer;
+    }
+
+    std::int8_t Collider::layer() const
+    {
+        return m_layer;
+    }
+
     Shape Collider::shape() const 
     {
         return Shape::Invalid;
@@ -82,8 +97,8 @@ namespace gamecoe
     {
         if (!m_active || !other.active()) return;
 
-        // other is a ShapeCollider
-        if (other.shape() != Shape::Invalid)
+        // ShapeCollider/ShapeCollider collision detection
+        if (shape() != Shape::Invalid && other.shape() != Shape::Invalid)
         {
             bool collided = collision::detect(m_owner.transform(), shape(), other.owner().transform(), other.shape());
 
@@ -112,7 +127,6 @@ namespace gamecoe
             other.m_collidedWith.insert(id);
             if (m_onCollisionBegin) m_onCollisionBegin(other);
             if (other.m_onCollisionBegin) other.m_onCollisionBegin(*this);
-            return;
         }
         // TODO: treat other Colliders
     }

--- a/src/gamecoe/entity/collider/collider.cpp
+++ b/src/gamecoe/entity/collider/collider.cpp
@@ -45,7 +45,6 @@ namespace gamecoe
 
     void Collider::deactivate() 
     {
-        auto id = m_owner.id();
         for (auto otherId : m_collidedWith)
         {
             auto go = m_owner.scene().findGameObject(otherId);

--- a/src/gamecoe/entity/collider/shape_collider.cpp
+++ b/src/gamecoe/entity/collider/shape_collider.cpp
@@ -4,9 +4,9 @@
 namespace gamecoe
 {
     ShapeCollider::ShapeCollider(GameObject &owner, Shape shape,
-        const std::function<void(const Collider&)> &onCollisionBegin,
-        const std::function<void(const Collider&)> &onCollision,
-        const std::function<void(const Collider&)> &onCollisionEnd,
+        const std::function<void(Collider&)> &onCollisionBegin,
+        const std::function<void(Collider&)> &onCollision,
+        const std::function<void(Collider&)> &onCollisionEnd,
         std::int8_t layer) : 
         Collider(owner, onCollisionBegin, onCollision, onCollisionEnd, layer), m_shape(shape)
     { 
@@ -51,9 +51,9 @@ namespace gamecoe
     }
 
     std::unique_ptr<ShapeCollider> ShapeCollider::triangle(GameObject &owner,
-        const std::function<void(const Collider&)> &onCollisionBegin,
-        const std::function<void(const Collider&)> &onCollision,
-        const std::function<void(const Collider&)> &onCollisionEnd,
+        const std::function<void(Collider&)> &onCollisionBegin,
+        const std::function<void(Collider&)> &onCollision,
+        const std::function<void(Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
         return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Triangle,
@@ -61,9 +61,9 @@ namespace gamecoe
     }
 
     std::unique_ptr<ShapeCollider> ShapeCollider::rectangle(GameObject &owner,
-        const std::function<void(const Collider&)> &onCollisionBegin,
-        const std::function<void(const Collider&)> &onCollision,
-        const std::function<void(const Collider&)> &onCollisionEnd,
+        const std::function<void(Collider&)> &onCollisionBegin,
+        const std::function<void(Collider&)> &onCollision,
+        const std::function<void(Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
         return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Rectangle,
@@ -71,9 +71,9 @@ namespace gamecoe
     }
 
     std::unique_ptr<ShapeCollider> ShapeCollider::box(GameObject &owner,
-        const std::function<void(const Collider&)> &onCollisionBegin,
-        const std::function<void(const Collider&)> &onCollision,
-        const std::function<void(const Collider&)> &onCollisionEnd,
+        const std::function<void(Collider&)> &onCollisionBegin,
+        const std::function<void(Collider&)> &onCollision,
+        const std::function<void(Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
         return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Box,
@@ -81,9 +81,9 @@ namespace gamecoe
     }
 
     std::unique_ptr<ShapeCollider> ShapeCollider::circle(GameObject &owner,
-        const std::function<void(const Collider&)> &onCollisionBegin,
-        const std::function<void(const Collider&)> &onCollision,
-        const std::function<void(const Collider&)> &onCollisionEnd,
+        const std::function<void(Collider&)> &onCollisionBegin,
+        const std::function<void(Collider&)> &onCollision,
+        const std::function<void(Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
         return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Circle,
@@ -91,9 +91,9 @@ namespace gamecoe
     }
 
     std::unique_ptr<ShapeCollider> ShapeCollider::sphere(GameObject &owner,
-        const std::function<void(const Collider&)> &onCollisionBegin,
-        const std::function<void(const Collider&)> &onCollision,
-        const std::function<void(const Collider&)> &onCollisionEnd,
+        const std::function<void(Collider&)> &onCollisionBegin,
+        const std::function<void(Collider&)> &onCollision,
+        const std::function<void(Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
         return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Sphere,

--- a/src/gamecoe/entity/collider/shape_collider.cpp
+++ b/src/gamecoe/entity/collider/shape_collider.cpp
@@ -1,0 +1,101 @@
+#include <gamecoe/entity/collider/shape_collider.hpp>
+#include <gamecoe/entity/game_object.hpp>
+
+namespace gamecoe
+{
+    ShapeCollider::ShapeCollider(GameObject &owner, Shape shape,
+        const std::function<void(const Collider&)> &onCollisionBegin,
+        const std::function<void(const Collider&)> &onCollision,
+        const std::function<void(const Collider&)> &onCollisionEnd,
+        std::int8_t layer) : 
+        Collider(owner, onCollisionBegin, onCollision, onCollisionEnd), m_shape(shape)
+    { 
+        
+    }
+
+    ShapeCollider::~ShapeCollider()
+    {
+
+    }
+
+    void ShapeCollider::initialize()
+    {
+
+    }
+
+    void ShapeCollider::begin()
+    {
+
+    }
+
+    void ShapeCollider::activate() 
+    {
+        m_active = true;
+    }
+
+    void ShapeCollider::deactivate() 
+    {
+        Collider::deactivate();
+        m_active = false;
+    }
+
+    void ShapeCollider::update()
+    {
+
+    }
+
+    Shape ShapeCollider::shape() const
+    {
+        return m_shape;
+    }
+
+    std::unique_ptr<ShapeCollider> ShapeCollider::triangle(GameObject &owner,
+        const std::function<void(const Collider&)> &onCollisionBegin,
+        const std::function<void(const Collider&)> &onCollision,
+        const std::function<void(const Collider&)> &onCollisionEnd,
+        std::int8_t layer)
+    {
+        return std::make_unique<ShapeCollider>(owner, Shape::Triangle, 
+            onCollisionBegin, onCollision, onCollisionEnd, layer);
+    }
+
+    std::unique_ptr<ShapeCollider> ShapeCollider::rectangle(GameObject &owner,
+        const std::function<void(const Collider&)> &onCollisionBegin,
+        const std::function<void(const Collider&)> &onCollision,
+        const std::function<void(const Collider&)> &onCollisionEnd,
+        std::int8_t layer)
+    {
+        return std::make_unique<ShapeCollider>(owner, Shape::Rectangle,
+            onCollisionBegin, onCollision, onCollisionEnd, layer);
+    }
+
+    std::unique_ptr<ShapeCollider> ShapeCollider::box(GameObject &owner,
+        const std::function<void(const Collider&)> &onCollisionBegin,
+        const std::function<void(const Collider&)> &onCollision,
+        const std::function<void(const Collider&)> &onCollisionEnd,
+        std::int8_t layer)
+    {
+        return std::make_unique<ShapeCollider>(owner, Shape::Box,
+            onCollisionBegin, onCollision, onCollisionEnd, layer);
+    }
+
+    std::unique_ptr<ShapeCollider> ShapeCollider::circle(GameObject &owner,
+        const std::function<void(const Collider&)> &onCollisionBegin,
+        const std::function<void(const Collider&)> &onCollision,
+        const std::function<void(const Collider&)> &onCollisionEnd,
+        std::int8_t layer)
+    {
+        return std::make_unique<ShapeCollider>(owner, Shape::Circle,
+            onCollisionBegin, onCollision, onCollisionEnd, layer);
+    }
+
+    std::unique_ptr<ShapeCollider> ShapeCollider::sphere(GameObject &owner,
+        const std::function<void(const Collider&)> &onCollisionBegin,
+        const std::function<void(const Collider&)> &onCollision,
+        const std::function<void(const Collider&)> &onCollisionEnd,
+        std::int8_t layer)
+    {
+        return std::make_unique<ShapeCollider>(owner, Shape::Sphere,
+            onCollisionBegin, onCollision, onCollisionEnd, layer);
+    }
+} // namespace gamecoe

--- a/src/gamecoe/entity/collider/shape_collider.cpp
+++ b/src/gamecoe/entity/collider/shape_collider.cpp
@@ -56,8 +56,8 @@ namespace gamecoe
         const std::function<void(const Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
-        return std::make_unique<ShapeCollider>(owner, Shape::Triangle, 
-            onCollisionBegin, onCollision, onCollisionEnd, layer);
+        return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Triangle,
+            onCollisionBegin, onCollision, onCollisionEnd, layer));
     }
 
     std::unique_ptr<ShapeCollider> ShapeCollider::rectangle(GameObject &owner,
@@ -66,8 +66,8 @@ namespace gamecoe
         const std::function<void(const Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
-        return std::make_unique<ShapeCollider>(owner, Shape::Rectangle,
-            onCollisionBegin, onCollision, onCollisionEnd, layer);
+        return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Rectangle,
+            onCollisionBegin, onCollision, onCollisionEnd, layer));
     }
 
     std::unique_ptr<ShapeCollider> ShapeCollider::box(GameObject &owner,
@@ -76,8 +76,8 @@ namespace gamecoe
         const std::function<void(const Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
-        return std::make_unique<ShapeCollider>(owner, Shape::Box,
-            onCollisionBegin, onCollision, onCollisionEnd, layer);
+        return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Box,
+            onCollisionBegin, onCollision, onCollisionEnd, layer));
     }
 
     std::unique_ptr<ShapeCollider> ShapeCollider::circle(GameObject &owner,
@@ -86,8 +86,8 @@ namespace gamecoe
         const std::function<void(const Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
-        return std::make_unique<ShapeCollider>(owner, Shape::Circle,
-            onCollisionBegin, onCollision, onCollisionEnd, layer);
+        return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Circle,
+            onCollisionBegin, onCollision, onCollisionEnd, layer));
     }
 
     std::unique_ptr<ShapeCollider> ShapeCollider::sphere(GameObject &owner,
@@ -96,7 +96,7 @@ namespace gamecoe
         const std::function<void(const Collider&)> &onCollisionEnd,
         std::int8_t layer)
     {
-        return std::make_unique<ShapeCollider>(owner, Shape::Sphere,
-            onCollisionBegin, onCollision, onCollisionEnd, layer);
+        return std::unique_ptr<ShapeCollider>(new ShapeCollider(owner, Shape::Sphere,
+            onCollisionBegin, onCollision, onCollisionEnd, layer));
     }
 } // namespace gamecoe

--- a/src/gamecoe/entity/collider/shape_collider.cpp
+++ b/src/gamecoe/entity/collider/shape_collider.cpp
@@ -8,7 +8,7 @@ namespace gamecoe
         const std::function<void(const Collider&)> &onCollision,
         const std::function<void(const Collider&)> &onCollisionEnd,
         std::int8_t layer) : 
-        Collider(owner, onCollisionBegin, onCollision, onCollisionEnd), m_shape(shape)
+        Collider(owner, onCollisionBegin, onCollision, onCollisionEnd, layer), m_shape(shape)
     { 
         
     }
@@ -30,6 +30,7 @@ namespace gamecoe
 
     void ShapeCollider::activate() 
     {
+        Collider::activate();
         m_active = true;
     }
 

--- a/src/gamecoe/entity/renderer/shape_renderer.cpp
+++ b/src/gamecoe/entity/renderer/shape_renderer.cpp
@@ -90,12 +90,13 @@ namespace gamecoe
         // Camera or Object moved, need to calculate visiblity
         if (transform.modelChanged() || camera.owner().transform().modelChanged())
         {
-            transform.modelMatrix(); // Updates the cached Model Matrix and the .modelChanged() result for next time
+            transform.modelMatrix();
             m_visible = camera.frustum().contains(transform, m_shape);
 
             bool is2D = m_shape == Shape::Triangle || m_shape == Shape::Rectangle || m_shape == Shape::Circle;
             if (is2D)
                 m_visible = m_visible && camera.facing(transform);
+            transform.clearModelChanged();
         }
 
         return m_visible;

--- a/src/gamecoe/entity/transform.cpp
+++ b/src/gamecoe/entity/transform.cpp
@@ -7,6 +7,7 @@ namespace gamecoe
     void Transform::invalidateCachedModel() const
     {
         m_modelChanged = true;
+        m_cachedModelValid = false;
 
         auto &children = m_owner.children();
         for (auto &child : children)
@@ -124,13 +125,13 @@ namespace gamecoe
 
     const glm::mat4 &Transform::modelMatrix() const
     {
-        if (!m_modelChanged) return m_cachedModelMatrix;
+        if (m_cachedModelValid) return m_cachedModelMatrix;
 
         glm::mat4 local = localMatrix();
 
         m_cachedModelMatrix = !m_owner.hasParent() ? local : m_owner.parent()->get().transform().modelMatrix() * local;
         m_cachedInverseModelMatrix = glm::inverse(m_cachedModelMatrix);
-        m_modelChanged = false;
+        m_cachedModelValid = true;
 
         return m_cachedModelMatrix;
     }
@@ -307,5 +308,10 @@ namespace gamecoe
     bool Transform::modelChanged() const
     {
         return m_modelChanged;
+    }
+
+    void Transform::clearModelChanged() const
+    {
+        m_modelChanged = false;
     }
 } // namespace gamecoe

--- a/src/gamecoe/graphics/texture.cpp
+++ b/src/gamecoe/graphics/texture.cpp
@@ -158,14 +158,14 @@ namespace gamecoe
                GL_LINEAR_MIPMAP_LINEAR;
     }
 
-    static inline unsigned int getCurrentBoundTextureId(int dimension)
+    static inline std::uint32_t getCurrentBoundTextureId(int dimension)
     {
         int textureBinding = (dimension == GL_TEXTURE_1D) ? GL_TEXTURE_BINDING_1D :
                              (dimension == GL_TEXTURE_2D) ? GL_TEXTURE_BINDING_2D :
                              GL_TEXTURE_BINDING_3D;
         GLint currentTexture;
         glGetIntegerv(textureBinding, &currentTexture);
-        return static_cast<unsigned int>(currentTexture);
+        return static_cast<std::uint32_t>(currentTexture);
     }
 #endif
 
@@ -179,14 +179,14 @@ namespace gamecoe
         }
 
 #if !GAMECOE_HAS_DSA
-        unsigned int currentTexture = getCurrentBoundTextureId(m_dimension);
+        std::uint32_t currentTexture = getCurrentBoundTextureId(m_dimension);
         
         struct AutomaticRebinding
         {
-            unsigned int m_texture;
+            std::uint32_t m_texture;
             int m_dimension;
             bool m_shouldRebind = false;
-            AutomaticRebinding(unsigned int tex, int dim) : m_texture(tex), m_dimension(dim) { }
+            AutomaticRebinding(std::uint32_t tex, int dim) : m_texture(tex), m_dimension(dim) { }
             ~AutomaticRebinding()
             {
                 if(m_shouldRebind)

--- a/src/gamecoe/graphics/vertex_array.cpp
+++ b/src/gamecoe/graphics/vertex_array.cpp
@@ -1,57 +1,20 @@
 #include <gamecoe/graphics/vertex_array.hpp>
+#include <gamecoe/utils/geometry.hpp>
 #include <gamecoe_config.hpp>
 
 #if GAMECOE_USE_OPENGL
 #include <glad/gl.h>
 #endif
 
-namespace 
-{
-    constexpr float triangleVertices[] = {
-        -0.5f, -0.5f, 0.0f,
-         0.5f, -0.5f, 0.0f,
-         0.0f,  0.5f, 0.0f
-    };
-
-    constexpr float rectangleVertices[] = {
-        -0.5f, -0.5f, 0.0f,
-         0.5f, -0.5f, 0.0f,
-         0.5f,  0.5f, 0.0f,
-        -0.5f,  0.5f, 0.0f
-    };
-    constexpr unsigned int rectangleIndices[] = {
-        0, 1, 2,
-        2, 3, 0
-    };
-
-    constexpr float boxVertices[] = {
-        -0.5f, -0.5f,  0.5f,
-         0.5f, -0.5f,  0.5f,
-         0.5f,  0.5f,  0.5f,
-        -0.5f,  0.5f,  0.5f,
-        -0.5f, -0.5f, -0.5f,
-         0.5f, -0.5f, -0.5f,
-         0.5f,  0.5f, -0.5f,
-        -0.5f,  0.5f, -0.5f
-    };
-    constexpr unsigned int boxIndices[] = {
-        0, 1, 2, 2, 3, 0,
-        4, 5, 6, 6, 7, 4,
-        7, 3, 0, 0, 4, 7,
-        1, 5, 6, 6, 2, 1,
-        4, 0, 1, 1, 5, 4,
-        3, 7, 6, 6, 2, 3
-    };
-}
-
 namespace gamecoe
 {
     std::vector<VertexArray*> VertexArray::s_shapeVAs = {};
 
     VertexArray::VertexArray(const float *vertices, size_t vertexCount, size_t vertexSize,
-                             const unsigned int *indices, size_t indexCount) :  m_id(0), 
-                                                                                m_vertexBuffer(VertexBuffer()), 
-                                                                                m_vertexCount(vertexCount)
+                             const std::uint32_t *indices, size_t indexCount) :  
+        m_id(0), 
+        m_vertexBuffer(VertexBuffer()), 
+        m_vertexCount(vertexCount)
     {
 #if GAMECOE_HAS_DSA
         glCreateVertexArrays(1, &m_id);
@@ -71,7 +34,7 @@ namespace gamecoe
         m_vertexBuffer.uploadData(vertices, vertexCount * vertexSize * sizeof(float));
 
         if (m_indexBuffer)
-            m_indexBuffer->uploadData(indices, indexCount * sizeof(unsigned int));
+            m_indexBuffer->uploadData(indices, indexCount * sizeof(std::uint32_t));
 
         setupVertexAttributes();
 #if !GAMECOE_HAS_DSA
@@ -162,7 +125,8 @@ namespace gamecoe
         static VertexArray *triangleVA = nullptr;
         if (!triangleVA)
         {
-            triangleVA = new VertexArray(triangleVertices, 3, 3);
+            static constexpr auto vertices = geometry::triangle::verticesFlat();
+            triangleVA = new VertexArray(vertices.data(), vertices.size() / 3, 3);
             s_shapeVAs.push_back(triangleVA);
         }
     
@@ -174,7 +138,9 @@ namespace gamecoe
         static VertexArray *rectangleVA = nullptr;
         if (!rectangleVA)
         {
-            rectangleVA = new VertexArray(rectangleVertices, 4, 3, rectangleIndices, 6);
+            static constexpr auto vertices = geometry::rectangle::verticesFlat();
+            static constexpr auto indices = geometry::rectangle::indices();
+            rectangleVA = new VertexArray(vertices.data(), vertices.size() / 3, 3, indices.data(), indices.size());
             s_shapeVAs.push_back(rectangleVA);
         }
         
@@ -186,7 +152,9 @@ namespace gamecoe
         static VertexArray *boxVA = nullptr;
         if (!boxVA)
         {
-            boxVA = new VertexArray(boxVertices, 8, 3, boxIndices, 36);
+            static constexpr auto vertices = geometry::box::verticesFlat();
+            static constexpr auto indices = geometry::box::indices();
+            boxVA = new VertexArray(vertices.data(), vertices.size() / 3, 3, indices.data(), indices.size());
             s_shapeVAs.push_back(boxVA);
         }
         

--- a/src/gamecoe/utils/collision.cpp
+++ b/src/gamecoe/utils/collision.cpp
@@ -221,7 +221,7 @@ namespace gamecoe
             return false; // not supported yet
         }
 
-        bool boxes(const Transform &t1, const Transform &t2)
+        bool boxes([[maybe_unused]] const Transform &t1, [[maybe_unused]] const Transform &t2)
         {
             return false; // not supported yet
         }
@@ -243,7 +243,7 @@ namespace gamecoe
             return false; // not supported yet
         }
 
-        bool spheres(const Transform &t1, const Transform &t2)
+        bool spheres([[maybe_unused]] const Transform &t1, [[maybe_unused]] const Transform &t2)
         {
             return false; // not supported yet
         }
@@ -266,7 +266,7 @@ namespace gamecoe
             return false; // not supported yet
         }
 
-        bool triangleWithBox(const Transform &t1, const Transform &t2)
+        bool triangleWithBox([[maybe_unused]] const Transform &t1, [[maybe_unused]] const Transform &t2)
         {
             return false; // not supported yet
         }
@@ -289,12 +289,12 @@ namespace gamecoe
             return false; // not supported yet
         }
 
-        bool triangleWithSphere(const Transform &t1, const Transform &t2)
+        bool triangleWithSphere([[maybe_unused]] const Transform &t1, [[maybe_unused]] const Transform &t2)
         {
             return false; // not supported yet
         }
 
-        bool rectangleWithBox(const Transform &t1, const Transform &t2)
+        bool rectangleWithBox([[maybe_unused]] const Transform &t1, [[maybe_unused]] const Transform &t2)
         {
             return false; // not supported yet
         }
@@ -317,22 +317,22 @@ namespace gamecoe
             return false; // not supported yet
         }
 
-        bool rectangleWithSphere(const Transform &t1, const Transform &t2)
+        bool rectangleWithSphere([[maybe_unused]] const Transform &t1, [[maybe_unused]] const Transform &t2)
         {
             return false; // not supported yet
         }
 
-        bool boxWithCircle(const Transform &t1, const Transform &t2)
+        bool boxWithCircle([[maybe_unused]] const Transform &t1, [[maybe_unused]] const Transform &t2)
         {
             return false; // not supported yet
         }
 
-        bool boxWithSphere(const Transform &t1, const Transform &t2)
+        bool boxWithSphere([[maybe_unused]] const Transform &t1, [[maybe_unused]] const Transform &t2)
         {
             return false; // not supported yet
         }
 
-        bool circleWithSphere(const Transform &t1, const Transform &t2)
+        bool circleWithSphere([[maybe_unused]] const Transform &t1, [[maybe_unused]] const Transform &t2)
         {
             return false; // not supported yet
         }
@@ -362,6 +362,7 @@ namespace gamecoe
                 case Shape::Circle:
                     return triangleWithCircle(first, second);
                 case Shape::Sphere:
+                default:
                     return triangleWithSphere(first, second);
                 }
                 break;
@@ -375,6 +376,7 @@ namespace gamecoe
                 case Shape::Circle:
                     return rectangleWithCircle(first, second);
                 case Shape::Sphere:
+                default:
                     return rectangleWithSphere(first, second);
                 }
                 break;
@@ -386,6 +388,7 @@ namespace gamecoe
                 case Shape::Circle:
                     return boxWithCircle(first, second);
                 case Shape::Sphere:
+                default:
                     return boxWithSphere(first, second);
                 }
                 break;
@@ -395,10 +398,12 @@ namespace gamecoe
                 case Shape::Circle:
                     return circles(first, second);
                 case Shape::Sphere:
+                default:
                     return circleWithSphere(first, second);
                 }
                 break;
             case Shape::Sphere:
+            default:
                 return spheres(first, second);
             }
 

--- a/src/gamecoe/utils/collision.cpp
+++ b/src/gamecoe/utils/collision.cpp
@@ -89,7 +89,7 @@ namespace gamecoe
         {
             bool uniformCircles(const Transform &t1, const Transform &t2)
             {
-                float radiusSum = t1.worldScale().x + t2.worldScale().x;
+                float radiusSum = (t1.worldScale().x / 2.0f) + (t2.worldScale().x / 2.0f); // default radius is 0.5f for scale 1.0f
                 glm::vec2 diff = t1.worldPosition() - t2.worldPosition();
                 float distanceSquared = glm::dot(diff, diff);
                 return distanceSquared <= radiusSum * radiusSum;

--- a/src/gamecoe/utils/collision.cpp
+++ b/src/gamecoe/utils/collision.cpp
@@ -149,7 +149,7 @@ namespace gamecoe
                     // if ray from point crosses edge - Jordan Curve Theorem (Ray Casting)
                     // then toggle inside/outside
                     if (((v1.y >= point.y && point.y > v2.y) || (v1.y < point.y && point.y <= v2.y)) &&
-                        (point.x < (((v2.x - v1.x) * (point.y - v1.y)) / ((v2.y - v1.y) + v1.x))))
+                        (point.x < ((((v2.x - v1.x) * (point.y - v1.y)) / (v2.y - v1.y)) + v1.x)))
                         inside = !inside;
                 }
 
@@ -174,7 +174,7 @@ namespace gamecoe
             {
                 for (std::size_t i = 0; i < N1; ++i)
                 {
-                    std::size_t next =(i == N1 - 1) ? 0 : i + 1;
+                    std::size_t next = (i == N1 - 1) ? 0 : i + 1;
                     // check collision
                     if (polygonWithLine(polygon2, polygon1[i], polygon1[next])) return true;
                 }

--- a/src/gamecoe/utils/collision.cpp
+++ b/src/gamecoe/utils/collision.cpp
@@ -1,0 +1,409 @@
+#include <gamecoe/utils/collision.hpp>
+#include <gamecoe/utils/geometry.hpp>
+#include <glm/glm.hpp>
+#include <cassert>
+#include <set>
+#include <utility>
+#include <algorithm>
+
+namespace gamecoe
+{
+    namespace collision
+    {
+        constexpr float g_epsilon = glm::epsilon<float>();
+
+        namespace vertices // To avoid holding more than 1 static vertices array for each shape
+        {
+            const std::array<glm::vec3, 3> &triangle()
+            {
+                static const std::array<glm::vec3, 3> vertices = geometry::triangle::vertices();
+                return vertices;
+            }
+
+            const std::array<glm::vec3, 4> &rectangle()
+            {
+                static const std::array<glm::vec3, 4> vertices = geometry::rectangle::vertices();
+                return vertices;
+            }
+
+            const std::array<glm::vec3, 16> &circle()
+            {
+                static const std::array<glm::vec3, 16> vertices = geometry::circle::vertices();
+                return vertices;
+            }
+        } // namespace vertices
+
+        namespace helpers
+        {
+            // Returns if the two Transforms have uniform scales
+            bool uniformScales(const Transform &t1, const Transform &t2)
+            {
+                auto scale1 = t1.worldScale();
+                auto scale2 = t2.worldScale();
+
+                bool epsilonEqual1 = glm::epsilonEqual(scale1.x, scale1.y, g_epsilon) &&
+                                    glm::epsilonEqual(scale1.y, scale1.z, g_epsilon);
+                if (!epsilonEqual1) return false;
+
+                bool epsilonEqual2 = glm::epsilonEqual(scale2.x, scale2.y, g_epsilon) &&
+                                    glm::epsilonEqual(scale2.y, scale2.z, g_epsilon);
+                if (!epsilonEqual2) return false;
+
+                return true;
+            }
+
+            // Returns if the two Transforms have the same z-axis position
+            bool sameZPosition(const Transform &t1, const Transform &t2)
+            {
+                return glm::epsilonEqual(t1.worldPosition().z, t2.worldPosition().z, g_epsilon);
+            }
+
+            // Returns if the two Transforms are both on the xy plane
+            bool xyPlane(const Transform &t1, const Transform &t2)
+            {
+                auto normal1 = glm::normalize(glm::vec3(0.0f, 0.0f, 1.0f) * t1.worldRotation());
+                auto normal2 = glm::normalize(glm::vec3(0.0f, 0.0f, 1.0f) * t2.worldRotation());
+                glm::vec3 xyPlaneNormal(0.0f, 0.0f, 1.0f);
+
+                bool t1InXY = std::abs(glm::dot(normal1, xyPlaneNormal)) > (1.0f - g_epsilon);
+                bool t2InXY = std::abs(glm::dot(normal2, xyPlaneNormal)) > (1.0f - g_epsilon);
+
+                return t1InXY && t2InXY;
+            }
+
+            // Returns if the two Transforms are both on the same plane
+            bool coplanar(const Transform &t1, const Transform &t2)
+            {
+                return glm::all(glm::epsilonEqual(t1.worldRotation(), t2.worldRotation(), g_epsilon));
+            }
+
+            // Returns if the two Transform both have the identity rotation
+            bool identityRotation(const Transform& t)
+            {
+                glm::quat identity(1.0f, 0.0f, 0.0f, 0.0f);
+                return glm::all(glm::epsilonEqual(t.worldRotation(), identity, g_epsilon));
+            }
+        } // namespace helpers
+
+        namespace simple2D
+        {
+            bool uniformCircles(const Transform &t1, const Transform &t2)
+            {
+                float radiusSum = t1.worldScale().x + t2.worldScale().x;
+                glm::vec2 diff = t1.worldPosition() - t2.worldPosition();
+                float distanceSquared = glm::dot(diff, diff);
+                return distanceSquared <= radiusSum * radiusSum;
+            }
+
+            bool aabbTest(const Transform &t1, const Transform &t2)
+            {
+                auto center1 = t1.worldPosition2D();
+                auto center2 = t2.worldPosition2D();
+
+                auto scale1 = t1.worldScale2D();
+                auto scale2 = t2.worldScale2D();
+                float halfWidth1 = scale1.x / 2.0f;
+                float halfwidth2 = scale2.x / 2.0f;
+                float halfheight1 = scale1.y / 2.0f;
+                float halfheight2 = scale2.y / 2.0f;
+
+                if (center1.x + halfWidth1 >= center2.x - halfwidth2 &&
+                    center1.x - halfWidth1 <= center2.x + halfwidth2 &&
+                    center1.y + halfheight1 >= center2.y - halfheight2 &&
+                    center1.y - halfheight1 <= center2.y + halfheight2) return true;
+                
+                return false;
+            }
+        } // namespace simpleCollisions
+
+        namespace complex2D
+        {
+            bool lines(const glm::vec3 &v1, const glm::vec3 &v2, const glm::vec3 &v3, const glm::vec3 &v4)
+            {
+                float denominator = ((v4.y - v3.y) * (v2.x - v1.x)) - ((v4.x - v3.x) * (v2.y - v1.y));
+                
+                // check for parallel lines
+                if (std::abs(denominator) < g_epsilon) 
+                    return false;
+
+                float uA = (((v4.x - v3.x) * (v1.y - v3.y)) - ((v4.y - v3.y) * (v1.x - v3.x))) / denominator;
+                float uB = (((v2.x - v1.x) * (v1.y - v3.y)) - ((v2.y - v1.y) * (v1.x - v3.x))) / denominator;
+                
+                // check collision
+                return ((0.0f <= uA && uA <= 1.0f) && (0.0f <= uB && uB <= 1.0f));
+            }
+
+            template<std::size_t N>
+            bool pointInsidePolygon(const std::array<glm::vec3, N> &polygon, const glm::vec3 &point)
+            {
+                bool inside = false;
+
+                for (std::size_t i = 0; i < N; ++i)
+                {
+                    std::size_t next = (i == N - 1) ? 0 : i + 1;
+                    const glm::vec3 &v1 = polygon[i];
+                    const glm::vec3 &v2 = polygon[next];
+
+                    // if point.y is between v1.y and v2.y
+                    // AND
+                    // if ray from point crosses edge - Jordan Curve Theorem (Ray Casting)
+                    // then toggle inside/outside
+                    if (((v1.y >= point.y && point.y > v2.y) || (v1.y < point.y && point.y <= v2.y)) &&
+                        (point.x < (((v2.x - v1.x) * (point.y - v1.y)) / ((v2.y - v1.y) + v1.x))))
+                        inside = !inside;
+                }
+
+                return inside;
+            }
+
+            template<std::size_t N>
+            bool polygonWithLine(const std::array<glm::vec3, N> &polygon, const glm::vec3 &v1, const glm::vec3 &v2)
+            {
+                for (std::size_t i = 0; i < N; ++i)
+                {
+                    std::size_t next = (i == N - 1) ? 0 : i + 1;
+                    // check collision
+                    if (lines(v1, v2, polygon[i], polygon[next])) return true;
+                }
+
+                return false;
+            }
+
+            template<std::size_t N1, std::size_t N2>
+            bool polygons(const std::array<glm::vec3, N1> &polygon1, const std::array<glm::vec3, N2> &polygon2)
+            {
+                for (std::size_t i = 0; i < N1; ++i)
+                {
+                    std::size_t next =(i == N1 - 1) ? 0 : i + 1;
+                    // check collision
+                    if (polygonWithLine(polygon2, polygon1[i], polygon1[next])) return true;
+                }
+
+                // check if one polygon is inside the other
+                if (pointInsidePolygon(polygon1, polygon2[0]) || pointInsidePolygon(polygon2, polygon1[0])) 
+                    return true;
+
+                return false;
+            }
+        } // namespace complex2D
+
+        bool triangles(const Transform &t1, const Transform &t2)
+        {
+            if (helpers::xyPlane(t1, t2) && helpers::sameZPosition(t1, t2))
+            {
+                if (helpers::identityRotation(t1) && helpers::identityRotation(t2) && !simple2D::aabbTest(t1, t2))
+                    return false;
+
+                const auto &vertices = vertices::triangle();
+                const auto triangleVertices1 = geometry::transformVertices(vertices, t1.modelMatrix());
+                const auto triangleVertices2 = geometry::transformVertices(vertices, t2.modelMatrix());
+                return complex2D::polygons(triangleVertices1, triangleVertices2);
+            }
+
+            // Triangles rotated in the 3D space
+            return false; // not supported yet
+        }
+
+        bool rectangles(const Transform &t1, const Transform &t2)
+        {
+            if (helpers::xyPlane(t1, t2) && helpers::sameZPosition(t1, t2))
+            {
+                if (helpers::identityRotation(t1) && helpers::identityRotation(t2))
+                    return simple2D::aabbTest(t1, t2);
+                
+                const auto &vertices = vertices::rectangle();
+                const auto rectangleVertices1 = geometry::transformVertices(vertices, t1.modelMatrix());
+                const auto rectangleVertices2 = geometry::transformVertices(vertices, t2.modelMatrix());
+                return complex2D::polygons(rectangleVertices1, rectangleVertices2);
+            }
+
+            // Rectangles rotated in the 3D space
+            return false; // not supported yet
+        }
+
+        bool boxes(const Transform &t1, const Transform &t2)
+        {
+            return false; // not supported yet
+        }
+
+        bool circles(const Transform &t1, const Transform &t2)
+        {
+            if (helpers::xyPlane(t1, t2) && helpers::sameZPosition(t1, t2))
+            {
+                if (helpers::uniformScales(t1, t2))
+                    return simple2D::uniformCircles(t1, t2);
+
+                const auto &vertices = vertices::circle();
+                auto circleVertices1 = geometry::transformVertices(vertices, t1.modelMatrix());
+                auto circleVertices2 = geometry::transformVertices(vertices, t2.modelMatrix());
+                return complex2D::polygons(circleVertices1, circleVertices2);
+            }
+
+            // Circles rotated in the 3D space
+            return false; // not supported yet
+        }
+
+        bool spheres(const Transform &t1, const Transform &t2)
+        {
+            return false; // not supported yet
+        }
+
+        bool triangleWithRectangle(const Transform &t1, const Transform &t2)
+        {
+            if (helpers::xyPlane(t1, t2) && helpers::sameZPosition(t1, t2))
+            {
+                if (helpers::identityRotation(t1) && helpers::identityRotation(t2) && 
+                    !simple2D::aabbTest(t1, t2))
+                    return false;
+
+                const auto triangle = geometry::transformVertices(vertices::triangle(), t1.modelMatrix());
+                const auto rectangle = geometry::transformVertices(vertices::rectangle(), t2.modelMatrix());
+
+                return complex2D::polygons(triangle, rectangle);
+            }           
+            
+            // triangle/rectangle rotated in the 3D space
+            return false; // not supported yet
+        }
+
+        bool triangleWithBox(const Transform &t1, const Transform &t2)
+        {
+            return false; // not supported yet
+        }
+
+        bool triangleWithCircle(const Transform &t1, const Transform &t2)
+        {
+            if (helpers::xyPlane(t1, t2) && helpers::sameZPosition(t1, t2))
+            {
+                if (helpers::identityRotation(t1) && helpers::identityRotation(t2) && 
+                    !simple2D::aabbTest(t1, t2))
+                    return false;
+
+                const auto triangle = geometry::transformVertices(vertices::triangle(), t1.modelMatrix());
+                const auto circle = geometry::transformVertices(vertices::circle(), t2.modelMatrix());
+
+                return complex2D::polygons(triangle, circle);
+            }
+
+            // triangle/circle rotated in the 3D space
+            return false; // not supported yet
+        }
+
+        bool triangleWithSphere(const Transform &t1, const Transform &t2)
+        {
+            return false; // not supported yet
+        }
+
+        bool rectangleWithBox(const Transform &t1, const Transform &t2)
+        {
+            return false; // not supported yet
+        }
+
+        bool rectangleWithCircle(const Transform &t1, const Transform &t2)
+        {
+            if (helpers::xyPlane(t1, t2) && helpers::sameZPosition(t1, t2))
+            {
+                if (helpers::identityRotation(t1) && helpers::identityRotation(t2) && 
+                    !simple2D::aabbTest(t1, t2))
+                    return false;
+
+                const auto rectangle = geometry::transformVertices(vertices::rectangle(), t1.modelMatrix());
+                const auto circle = geometry::transformVertices(vertices::circle(), t2.modelMatrix());
+
+                return complex2D::polygons(rectangle, circle);
+            }
+
+            // rectangle/circle rotated in the 3D space
+            return false; // not supported yet
+        }
+
+        bool rectangleWithSphere(const Transform &t1, const Transform &t2)
+        {
+            return false; // not supported yet
+        }
+
+        bool boxWithCircle(const Transform &t1, const Transform &t2)
+        {
+            return false; // not supported yet
+        }
+
+        bool boxWithSphere(const Transform &t1, const Transform &t2)
+        {
+            return false; // not supported yet
+        }
+
+        bool circleWithSphere(const Transform &t1, const Transform &t2)
+        {
+            return false; // not supported yet
+        }
+
+        bool detect(const Transform &t1, Shape s1, const Transform &t2, Shape s2)
+        {
+            assert(s1 != Shape::Invalid && s2 != Shape::Invalid); // not suppose to happen
+
+            bool shapeOrder = s1 < s2;
+            std::pair<Shape, Shape> shapes = shapeOrder ? 
+                                                std::pair<Shape, Shape>(s1, s2) : 
+                                                std::pair<Shape, Shape>(s2, s1);
+            const Transform &first = shapeOrder ? t1 : t2;
+            const Transform &second = shapeOrder ? t2 : t1;
+
+            switch(shapes.first)
+            {
+            case Shape::Triangle:
+                switch(shapes.second)
+                {
+                case Shape::Triangle:
+                    return triangles(first, second);
+                case Shape::Rectangle:
+                    return triangleWithRectangle(first, second);
+                case Shape::Box:
+                    return triangleWithBox(first, second);
+                case Shape::Circle:
+                    return triangleWithCircle(first, second);
+                case Shape::Sphere:
+                    return triangleWithSphere(first, second);
+                }
+                break;
+            case Shape::Rectangle:
+                switch(shapes.second)
+                {
+                case Shape::Rectangle:
+                    return rectangles(first, second);
+                case Shape::Box:
+                    return rectangleWithBox(first, second);
+                case Shape::Circle:
+                    return rectangleWithCircle(first, second);
+                case Shape::Sphere:
+                    return rectangleWithSphere(first, second);
+                }
+                break;
+            case Shape::Box:
+                switch(shapes.second)
+                {
+                case Shape::Box:
+                    return boxes(first, second);
+                case Shape::Circle:
+                    return boxWithCircle(first, second);
+                case Shape::Sphere:
+                    return boxWithSphere(first, second);
+                }
+                break;
+            case Shape::Circle:
+                switch(shapes.second)
+                {
+                case Shape::Circle:
+                    return circles(first, second);
+                case Shape::Sphere:
+                    return circleWithSphere(first, second);
+                }
+                break;
+            case Shape::Sphere:
+                return spheres(first, second);
+            }
+
+            assert(false);
+            return false;
+        }
+    } // namespace collision
+} // namespace gamecoe

--- a/src/gamecoe/utils/geometry.cpp
+++ b/src/gamecoe/utils/geometry.cpp
@@ -1,0 +1,67 @@
+#include <gamecoe/utils/geometry.hpp>
+#include <glm/gtc/constants.hpp>
+#include <cmath>
+
+namespace gamecoe
+{
+    namespace geometry
+    {
+        const std::array<glm::vec3, 16>& circle::vertices()
+        {
+            static const std::array<glm::vec3, 16> verts = []() {
+                std::array<glm::vec3, 16> result;
+                constexpr float radius = 0.5f;
+                constexpr int count = 16;
+
+                for (int i = 0; i < count; ++i) {
+                    float angle = (glm::two_pi<float>() * i) / count;
+                    result[i] = glm::vec3{
+                        radius * std::cos(angle),
+                        radius * std::sin(angle),
+                        0.0f
+                    };
+                }
+
+                return result;
+            }();
+
+            return verts;
+        }
+
+        const std::array<glm::vec3, 42>& sphere::vertices()
+        {
+            static const std::array<glm::vec3, 42> verts = []() {
+                std::array<glm::vec3, 42> result;
+                constexpr float radius = 0.5f;
+
+                // UV Sphere: 6 rings (latitude) × 7 segments (longitude) = 42 vertices
+                // This gives even distribution across the sphere surface
+                constexpr int rings = 6;
+                constexpr int segments = 7;
+                int index = 0;
+
+                for (int ring = 0; ring < rings; ++ring) {
+                    float theta = glm::pi<float>() * (ring + 1) / (rings + 1); // Latitude angle
+                    float sinTheta = std::sin(theta);
+                    float cosTheta = std::cos(theta);
+
+                    for (int seg = 0; seg < segments; ++seg) {
+                        float phi = glm::two_pi<float>() * seg / segments; // Longitude angle
+                        float sinPhi = std::sin(phi);
+                        float cosPhi = std::cos(phi);
+
+                        result[index++] = glm::vec3{
+                            radius * sinTheta * cosPhi,
+                            radius * cosTheta,
+                            radius * sinTheta * sinPhi
+                        };
+                    }
+                }
+
+                return result;
+            }();
+
+            return verts;
+        }
+    } // namespace geometry
+} // namespace gamecoe


### PR DESCRIPTION
  - Add abstract Collider Component base class
  - Add ShapeCollider Component class with factory methods for triangle/rectangle/box/circle/sphere
  - Implement edge intersection algorithm for 2D coplanar polygon collision
  - Support all 2D shapes collision detection when both shapes are on xy plane
  - Implement three collision callbacks: onCollisionBegin->onCollision->onCollisionEnd
  - Add layer based collision system, when same layer objects don't collide
  - Implement delayed add/remove pattern in Game class to safely handle collider modifications during collision callbacks
  - Extract shape geometry to utils/geometry.hpp with namespace organization by shape
  - Add transformVertices() template utility for batch vertex transformation
  - Change circle/sphere default radius from 1.0 to 0.5 for consistency with triangle/rectangle/box shapes
  - Separate Transform m_modelChanged (frame tracking) from m_cachedModelValid (cache validity)
  - Optimize GameObject template methods with constexpr if for compile-time type checking
  - Add deleted copy/move constructors and assignment operators to GameObject
  - Update VertexArray to use std::uint32_t instead of unsigned int
  - Make GLM a public linking dependency for collision detection API
  - Defer 3D collision detection (rotated shapes in 3D space, box/sphere collisions) to future PRs