### PR TITLE
[API]: Enhance sparse_set with generation packing

### DIFF
--- a/include/gamecoe/entity/entity.hpp
+++ b/include/gamecoe/entity/entity.hpp
@@ -9,13 +9,14 @@ namespace gamecoe
 {
     struct entity
     {
-        static constexpr std::uint32_t INVALID = std::numeric_limits<std::uint32_t>::max();
         static constexpr std::uint8_t ID_BITS = 20;
         static constexpr std::uint8_t GEN_BITS = 12;
         static constexpr std::uint32_t ID_MASK = (1U << ID_BITS) - 1;
         static constexpr std::uint32_t GEN_MASK = (1U << GEN_BITS) - 1;
         static constexpr std::uint32_t MAX_ENTITIES = ID_MASK - 1;  // 1,048,574
         static constexpr std::uint16_t MAX_GENERATIONS = GEN_MASK;  // 4,095
+
+        static constexpr entity invalid() noexcept { return entity{std::numeric_limits<std::uint32_t>::max()}; }
 
         static entity create(std::uint32_t id, std::uint16_t generation)
         {
@@ -27,17 +28,17 @@ namespace gamecoe
             return entity((id << GEN_BITS) | generation);
         }
 
-        auto operator<=>(const entity &other) const = default;
-        bool operator==(const entity &other) const = default;
+        auto operator<=>(const entity &other) const noexcept = default;
+        bool operator==(const entity &other) const noexcept = default;
 
-        bool valid() const { return m_value < INVALID; }
+        bool valid() const noexcept { return *this != invalid(); }
 
-        std::uint32_t id() const { return (m_value >> GEN_BITS) & ID_MASK; }
-        std::uint16_t generation() const { return m_value & GEN_MASK; }
+        std::uint32_t id() const noexcept { return (m_value >> GEN_BITS) & ID_MASK; }
+        std::uint16_t generation() const noexcept { return m_value & GEN_MASK; }
     
     private:
         std::uint32_t m_value;
 
-        explicit entity(std::uint32_t value = INVALID) : m_value(value) { }
+        explicit entity(std::uint32_t value) : m_value(value) { }
     };
 } // namespace gamecoe

--- a/include/gamecoe/entity/sparse_set.hpp
+++ b/include/gamecoe/entity/sparse_set.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cstddef>
 #include <gamecoe/entity/entity.hpp>
 #include <cstdint>
+#include <limits>
+#include <optional>
 #include <vector>
 #include <memory>
 #include <array>
@@ -11,6 +14,7 @@ namespace gamecoe
     class sparse_set
     {
         static constexpr std::uint16_t PAGE_SIZE = 1024;
+        static constexpr std::uint32_t TOMBSTONE = std::numeric_limits<std::uint32_t>::max();
 
         using page_type = std::array<std::uint32_t, PAGE_SIZE>;
         using page_ptr_type = std::unique_ptr<page_type>;
@@ -18,9 +22,16 @@ namespace gamecoe
         std::vector<page_ptr_type> m_sparse;
         std::vector<entity> m_dense;
 
-        std::uint16_t index_in_page(const entity &e) const { return e.id() % PAGE_SIZE; }
-        std::uint32_t page_index(const entity &e) const { return e.id() / PAGE_SIZE; }
-    
+        std::uint16_t index_in_page(const entity &e) const noexcept { return e.id() % PAGE_SIZE; }
+        std::uint32_t page_index(const entity &e) const noexcept { return e.id() / PAGE_SIZE; }
+
+        std::uint32_t unpack_dense_index(std::uint32_t packed) const noexcept { return packed & entity::ID_MASK; }
+        std::uint16_t unpack_generation(std::uint32_t packed) const noexcept { return packed >> entity::ID_BITS; }
+        std::uint32_t pack_dense_index(std::uint32_t dense_index, std::uint16_t generation) const noexcept
+        {
+            return (generation << entity::ID_BITS) | dense_index;
+        }
+        
     public:
         sparse_set() = default;
         sparse_set(const sparse_set&) = delete;
@@ -30,77 +41,72 @@ namespace gamecoe
 
         ~sparse_set() = default;
 
+        void reserve(std::size_t capacity) { m_dense.reserve(capacity); }
+
         void insert(const entity &e)
         {
+            if (contains(e)) return;
+            assert(m_dense.size() <= entity::MAX_ENTITIES && "sparse_set::insert(): max entities exceeded"); // sanity check
+
             auto page_i = page_index(e);
-            if (page_i >= m_sparse.size()) m_sparse.resize(page_i + 1);
+            if (page_i >= m_sparse.size()) 
+                m_sparse.resize(page_i + 1);
 
             auto &page = m_sparse[page_i];
-            if (!page) page = std::make_unique<page_type>();
+            if (!page) 
+            {
+                page = std::make_unique<page_type>();
+                page->fill(TOMBSTONE);
+            }
             
-            auto &dense_index = (*page)[index_in_page(e)];
-            if (m_dense.size() > dense_index && m_dense[dense_index] == e) return;
-
-            dense_index = m_dense.size();
+            (*page)[index_in_page(e)] = pack_dense_index(m_dense.size(), e.generation());
             m_dense.push_back(e);
         }
 
         void erase(const entity &e)
         {
-            auto page_i = page_index(e);
-            if (page_i >= m_sparse.size()) return;
+            if (!contains(e)) return;
 
-            auto &page = m_sparse[page_i];
-            if (!page) return;
-
-            auto dense_index = (*page)[index_in_page(e)];
-            if (m_dense.size() <= dense_index || m_dense[dense_index] != e) return;
+            auto &page = m_sparse[page_index(e)];
+            auto dense_index = unpack_dense_index((*page)[index_in_page(e)]);
 
             auto swapped = m_dense.back();
             m_dense[dense_index] = swapped;
             m_dense.pop_back();
 
+            (*page)[index_in_page(e)] = TOMBSTONE;
+
             if (swapped == e) return;
             
             auto &swapped_page = m_sparse[page_index(swapped)];
-            (*swapped_page)[index_in_page(swapped)] = dense_index;
+            (*swapped_page)[index_in_page(swapped)] = pack_dense_index(dense_index, swapped.generation());
         }
 
-        std::uint32_t index(const entity &e) const
+        std::optional<std::uint32_t> index(const entity &e) const
         {
-            auto page_i = page_index(e);
-            assert((page_i < m_sparse.size()) && "sparse_set::index(): entity not found");
+            if (!contains(e)) return std::nullopt;
 
-            const auto &page = m_sparse[page_i];
-            assert(page && "sparse_set::index(): entity not found");
-
-            auto dense_index = (*page)[index_in_page(e)];
-            assert((dense_index < m_dense.size() && m_dense[dense_index] == e) && "sparse_set::index(): entity not found");
-
-            return dense_index;
+            return unpack_dense_index((*m_sparse[page_index(e)])[index_in_page(e)]);
         }
 
-        bool contains(const entity &e) const
+        bool contains(const entity &e) const noexcept
         { 
             auto page_i = page_index(e);
-            if (page_i >= m_sparse.size()) return false;
 
-            const auto &page = m_sparse[page_i];
-            if (!page) return false;
-
-            auto dense_index = (*page)[index_in_page(e)];
-            return dense_index < m_dense.size() && m_dense[dense_index] == e;
+            return page_i < m_sparse.size() && m_sparse[page_i] && 
+                   unpack_generation((*m_sparse[page_i])[index_in_page(e)]) == e.generation();
         }
 
         void clear() { m_sparse.clear(); m_dense.clear(); }
-        std::size_t size() const { return m_dense.size(); }
-        bool empty() const { return m_dense.empty(); }
+        std::size_t size() const noexcept { return m_dense.size(); }
+        bool empty() const noexcept { return m_dense.empty(); }
 
-        entity *begin() { return m_dense.data(); }
-        entity *end() { return m_dense.data() + m_dense.size(); }
-        const entity *begin() const { return m_dense.data(); }
-        const entity *end() const { return m_dense.data() + m_dense.size(); }
-        const entity *cbegin() const { return begin(); }
-        const entity *cend() const { return end(); }
+        // Iterators invalidated by insert/erase (dense array reallocation)
+        entity *begin() noexcept { return m_dense.data(); }
+        entity *end() noexcept { return m_dense.data() + m_dense.size(); }
+        const entity *begin() const noexcept { return m_dense.data(); }
+        const entity *end() const noexcept { return m_dense.data() + m_dense.size(); }
+        const entity *cbegin() const noexcept { return begin(); }
+        const entity *cend() const noexcept { return end(); }
     };
 } // namespace gamecoe


### PR DESCRIPTION
- Implement generation packing optimization in sparse_set
- Replace entity::INVALID with entity::invalid() static factory function
- Add noexcept specifications to query methods
- Change sparse_set::index() to return std::optional