### PR TITLE
[Feature]: Implement extraction system for multi-component queries

### DIFF
--- a/include/gamecoe/entity/component_pool.hpp
+++ b/include/gamecoe/entity/component_pool.hpp
@@ -25,6 +25,8 @@ namespace gamecoe
         std::size_t size() const noexcept { return m_entities.size(); }
         bool empty() const noexcept { return m_entities.empty(); }
         void reserve(std::size_t capacity) { m_entities.reserve(capacity); do_reserve(capacity); }
+
+        entity get_entity_at_index(std::size_t index) const noexcept { return m_entities.get_entity_at_index(index); }
     };
 
     template <typename T>

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -3,6 +3,8 @@
 #include <cstddef>
 #include <gamecoe/entity/entity.hpp>
 #include <gamecoe/entity/component_pool.hpp>
+#include <gamecoe/entity/extraction.hpp>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include <memory>
@@ -122,7 +124,7 @@ namespace gamecoe
         }
 
         // Iterates over all entities and their components and run func() on each of them
-        template<typename T, typename Func>
+        template <typename T, typename Func>
         void for_each(Func &&func)
         {
             std::uint32_t comp_id = component_id<T>();
@@ -133,7 +135,7 @@ namespace gamecoe
         }
 
         // Iterates over all entities and their components and run func() on each of them
-        template<typename T, typename Func>
+        template <typename T, typename Func>
         void for_each(Func &&func) const
         {
             std::uint32_t comp_id = component_id<T>();
@@ -141,6 +143,18 @@ namespace gamecoe
 
             auto pool = static_cast<const component_pool<T>*>(m_pools[comp_id].get());
             pool->for_each(std::forward<Func>(func));
+        }
+
+        template <typename... Components>
+        extraction<Components...> extract()
+        {
+            return extraction<Components...>(get_pool<std::remove_const_t<Components>>()...);
+        }
+
+        template <typename... Components>
+        extraction<std::add_const_t<Components>...> extract() const
+        {
+            return extraction<std::add_const_t<Components>...>(const_cast<entities*>(this)->get_pool<Components>()...);
         }
     };
 } // namespace gamecoe

--- a/include/gamecoe/entity/extraction.hpp
+++ b/include/gamecoe/entity/extraction.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <cstddef>
+#include <gamecoe/entity/entity.hpp>
+#include <gamecoe/entity/component_pool.hpp>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace gamecoe
+{
+    template <typename... Components>
+    class extraction
+    {
+        std::tuple<component_pool<std::remove_const_t<Components>>*...> m_pools;
+        std::size_t m_smallest_pool_index;
+        std::size_t m_smallest_pool_size;
+
+    public:
+        class iterator
+        {
+            const extraction* m_extracted;
+            std::size_t m_index;
+
+            template <std::size_t... Is>
+            entity get_current_entity(std::index_sequence<Is...>) const
+            {
+                if (m_index >= m_extracted->m_smallest_pool_size) return entity::invalid();
+
+                entity e = entity::invalid();
+
+                ((Is == m_extracted->m_smallest_pool_index ?
+                    (e = std::get<Is>(m_extracted->m_pools)->get_entity_at_index(m_index), true) : false) 
+                || ...);
+
+                return e;
+            }
+
+            bool has_all_components(entity e) const
+            {
+                return (std::get<component_pool<std::remove_const_t<Components>>*>(m_extracted->m_pools)->contains(e) && ...);
+            }
+
+            void next()
+            {
+                while (m_index < m_extracted->m_smallest_pool_size)
+                {
+                    entity e = get_current_entity(std::index_sequence_for<Components...>{});
+
+                    if (has_all_components(e)) return;
+                    ++m_index; // entity e is not in all pools -> check the next one
+                }
+            }
+
+            template <std::size_t... Is>
+            std::tuple<entity, Components&...> get_current_tuple(std::index_sequence<Is...>) const
+            {
+                entity e = get_current_entity(std::index_sequence_for<Components...>{});
+
+                return std::tuple<entity, Components&...> {
+                    e,
+                    std::get<Is>(m_extracted->m_pools)->get(e)...
+                };
+            }
+
+        public:
+            iterator(const extraction* e, std::size_t index = 0) : m_extracted(e), m_index(index) { next(); }
+
+            std::tuple<entity, Components&...> operator*() const
+            {
+                return get_current_tuple(std::index_sequence_for<Components...>{});
+            }
+
+            iterator& operator++() { ++m_index; next(); return *this; }
+            iterator operator++(int) { iterator tmp = *this; ++m_index; next(); return tmp; }
+
+            bool operator==(const iterator &other) const { return m_index == other.m_index; }
+            bool operator!=(const iterator &other) const { return m_index != other.m_index; }
+        };
+
+        explicit extraction(component_pool<std::remove_const_t<Components>>*... pools) : m_pools(pools...)
+        {
+            std::size_t sizes[] = { pools->size()... };
+
+            m_smallest_pool_index = 0;
+            m_smallest_pool_size = sizes[0];
+
+            for(std::size_t i = 1; i < sizeof...(Components); ++i)
+            {
+                if (sizes[i] < m_smallest_pool_size)
+                {
+                    m_smallest_pool_size = sizes[i];
+                    m_smallest_pool_index = i;
+                }
+            }
+        }
+
+        iterator begin() const { return iterator(this); }
+        iterator end() const { return iterator(this, m_smallest_pool_size); }
+        const iterator cbegin() const { return begin(); }
+        const iterator cend() const { return end(); }
+    };
+} // namespace gamecoe

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(gamecoe_tests
     entity/sparse_set_tests.cpp
     entity/component_pool_tests.cpp
     entity/entities_tests.cpp
+    entity/extraction_tests.cpp
 )
 
 target_link_libraries(gamecoe_tests

--- a/tests/entity/component_pool_tests.cpp
+++ b/tests/entity/component_pool_tests.cpp
@@ -87,40 +87,44 @@ protected:
 };
 
 //==============================================================================
-//                        Add and Get Components
+//                        Add and Get Operations
 //==============================================================================
 
-TEST_F(ComponentPoolTests, AddAndGetComponent)
+TEST_F(ComponentPoolTests, AddAndGetOperations)
 {
-    auto e = entity::create(42, 0);
-
-    Position &pos = pool.add(e, Position{1.0f, 2.0f, 3.0f});
-
-    EXPECT_TRUE(pool.contains(e));
-    EXPECT_EQ(pool.size(), 1);
-    EXPECT_FALSE(pool.empty());
-    EXPECT_EQ(pool.get(e), pos);
-
-    // Modify and verify changes persist
-    pool.get(e).x = 99.0f;
-    EXPECT_EQ(pool.get(e).x, 99.0f);
-}
-
-TEST_F(ComponentPoolTests, AddMultiple)
-{
-    std::vector<entity> entities;
-
-    for (std::uint32_t i = 0; i < 50; ++i)
+    // Test 1: Add and get single component
     {
-        auto e = entity::create(i, 0);
-        entities.push_back(e);
-        pool.add(e, Position{static_cast<float>(i), 0.0f, 0.0f});
+        auto e = entity::create(42, 0);
+
+        Position &pos = pool.add(e, Position{1.0f, 2.0f, 3.0f});
+
+        EXPECT_TRUE(pool.contains(e));
+        EXPECT_EQ(pool.size(), 1);
+        EXPECT_FALSE(pool.empty());
+        EXPECT_EQ(pool.get(e), pos);
+
+        // Modify and verify changes persist
+        pool.get(e).x = 99.0f;
+        EXPECT_EQ(pool.get(e).x, 99.0f);
     }
 
-    EXPECT_EQ(pool.size(), 50);
+    // Test 2: Add multiple components
+    {
+        pool.clear();
+        std::vector<entity> entities;
 
-    for (std::size_t i = 0; i < entities.size(); ++i)
-        EXPECT_EQ(pool.get(entities[i]).x, static_cast<float>(i));
+        for (std::uint32_t i = 0; i < 50; ++i)
+        {
+            auto e = entity::create(i, 0);
+            entities.push_back(e);
+            pool.add(e, Position{static_cast<float>(i), 0.0f, 0.0f});
+        }
+
+        EXPECT_EQ(pool.size(), 50);
+
+        for (std::size_t i = 0; i < entities.size(); ++i)
+            EXPECT_EQ(pool.get(entities[i]).x, static_cast<float>(i));
+    }
 }
 
 //==============================================================================

--- a/tests/entity/entities_tests.cpp
+++ b/tests/entity/entities_tests.cpp
@@ -32,133 +32,150 @@ protected:
 //                        Entity Lifecycle
 //==============================================================================
 
-TEST_F(EntitiesTests, CreateAndValid)
+TEST_F(EntitiesTests, EntityLifecycle)
 {
-    entity e = mgr.create();
+    // Test 1: Create and validate single entity
+    {
+        entity e = mgr.create();
 
-    EXPECT_TRUE(mgr.valid(e));
-    EXPECT_TRUE(e != entity::invalid());
-    EXPECT_EQ(mgr.size(), 1);
-}
+        EXPECT_TRUE(mgr.valid(e));
+        EXPECT_TRUE(e != entity::invalid());
+        EXPECT_EQ(mgr.size(), 1);
+    }
 
-TEST_F(EntitiesTests, CreateMultiple)
-{
-    entity e0 = mgr.create();
-    entity e1 = mgr.create();
-    entity e2 = mgr.create();
+    // Test 2: Create multiple entities
+    {
+        mgr.clear();
 
-    EXPECT_EQ(mgr.size(), 3);
-    EXPECT_TRUE(mgr.valid(e0));
-    EXPECT_TRUE(mgr.valid(e1));
-    EXPECT_TRUE(mgr.valid(e2));
+        entity e0 = mgr.create();
+        entity e1 = mgr.create();
+        entity e2 = mgr.create();
 
-    // IDs should be distinct
-    EXPECT_NE(e0, e1);
-    EXPECT_NE(e1, e2);
+        EXPECT_EQ(mgr.size(), 3);
+        EXPECT_TRUE(mgr.valid(e0));
+        EXPECT_TRUE(mgr.valid(e1));
+        EXPECT_TRUE(mgr.valid(e2));
 
-    // Handles should be ordered by creation (ID-major layout)
-    EXPECT_LT(e0, e1);
-    EXPECT_LT(e1, e2);
-}
+        // IDs should be distinct
+        EXPECT_NE(e0, e1);
+        EXPECT_NE(e1, e2);
 
-TEST_F(EntitiesTests, DestroyEntity)
-{
-    entity e = mgr.create();
-    EXPECT_EQ(mgr.size(), 1);
+        // Handles should be ordered by creation (ID-major layout)
+        EXPECT_LT(e0, e1);
+        EXPECT_LT(e1, e2);
+    }
 
-    mgr.destroy(e);
+    // Test 3: Destroy entity
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        EXPECT_EQ(mgr.size(), 1);
 
-    EXPECT_FALSE(mgr.valid(e));
-    EXPECT_EQ(mgr.size(), 0);
-}
+        mgr.destroy(e);
 
-TEST_F(EntitiesTests, RecycleId)
-{
-    entity e0 = mgr.create();
-    std::uint32_t original_id = e0.id();
-    std::uint16_t original_gen = e0.generation();
+        EXPECT_FALSE(mgr.valid(e));
+        EXPECT_EQ(mgr.size(), 0);
+    }
 
-    mgr.destroy(e0);
+    // Test 4: Recycle entity ID with incremented generation
+    {
+        mgr.clear();
+        entity e0 = mgr.create();
+        std::uint32_t original_id = e0.id();
+        std::uint16_t original_gen = e0.generation();
 
-    entity e1 = mgr.create();
+        mgr.destroy(e0);
 
-    // Same ID recycled, generation incremented
-    EXPECT_EQ(e1.id(), original_id);
-    EXPECT_EQ(e1.generation(), original_gen + 1);
+        entity e1 = mgr.create();
 
-    // Old handle is stale, new one is valid
-    EXPECT_FALSE(mgr.valid(e0));
-    EXPECT_TRUE(mgr.valid(e1));
-}
+        // Same ID recycled, generation incremented
+        EXPECT_EQ(e1.id(), original_id);
+        EXPECT_EQ(e1.generation(), original_gen + 1);
 
-TEST_F(EntitiesTests, ClearEntities)
-{
-    entity e0 = mgr.create();
-    entity e1 = mgr.create();
-    entity e2 = mgr.create();
+        // Old handle is stale, new one is valid
+        EXPECT_FALSE(mgr.valid(e0));
+        EXPECT_TRUE(mgr.valid(e1));
+    }
 
-    mgr.clear();
+    // Test 5: Clear all entities
+    {
+        mgr.clear();
+        entity e0 = mgr.create();
+        entity e1 = mgr.create();
+        entity e2 = mgr.create();
 
-    EXPECT_EQ(mgr.size(), 0);
-    EXPECT_FALSE(mgr.valid(e0));
-    EXPECT_FALSE(mgr.valid(e1));
-    EXPECT_FALSE(mgr.valid(e2));
+        mgr.clear();
+
+        EXPECT_EQ(mgr.size(), 0);
+        EXPECT_FALSE(mgr.valid(e0));
+        EXPECT_FALSE(mgr.valid(e1));
+        EXPECT_FALSE(mgr.valid(e2));
+    }
 }
 
 //==============================================================================
 //                        Component Operations
 //==============================================================================
 
-TEST_F(EntitiesTests, AddHasGetRemoveComponent)
+TEST_F(EntitiesTests, ComponentOperations)
 {
-    entity e = mgr.create();
+    // Test 1: Add, has, get, remove component
+    {
+        entity e = mgr.create();
 
-    // Add
-    mgr.add_component<Position>(e, Position{1.0f, 2.0f, 3.0f});
-    EXPECT_TRUE(mgr.has_component<Position>(e));
+        // Add
+        mgr.add_component<Position>(e, Position{1.0f, 2.0f, 3.0f});
+        EXPECT_TRUE(mgr.has_component<Position>(e));
 
-    // Get (mutable)
-    Position *pos = mgr.get_component<Position>(e);
-    EXPECT_NE(pos, nullptr);
-    EXPECT_EQ(pos->x, 1.0f);
+        // Get (mutable)
+        Position *pos = mgr.get_component<Position>(e);
+        EXPECT_NE(pos, nullptr);
+        EXPECT_EQ(pos->x, 1.0f);
 
-    // Modify and verify
-    pos->x = 99.0f;
-    EXPECT_EQ(mgr.get_component<Position>(e)->x, 99.0f);
+        // Modify and verify
+        pos->x = 99.0f;
+        EXPECT_EQ(mgr.get_component<Position>(e)->x, 99.0f);
 
-    // Remove
-    mgr.remove_component<Position>(e);
-    EXPECT_FALSE(mgr.has_component<Position>(e));
-    EXPECT_EQ(mgr.get_component<Position>(e), nullptr);
+        // Remove
+        mgr.remove_component<Position>(e);
+        EXPECT_FALSE(mgr.has_component<Position>(e));
+        EXPECT_EQ(mgr.get_component<Position>(e), nullptr);
 
-    // Entity still valid after component removal
-    EXPECT_TRUE(mgr.valid(e));
+        // Entity still valid after component removal
+        EXPECT_TRUE(mgr.valid(e));
+    }
+
+    // Test 2: Get component with const manager
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        mgr.add_component<Position>(e, Position{5.0f, 6.0f, 7.0f});
+
+        const entities &const_mgr = mgr;
+        const Position *pos = const_mgr.get_component<Position>(e);
+
+        EXPECT_NE(pos, nullptr);
+        EXPECT_EQ(pos->x, 5.0f);
+        static_assert(std::is_same_v<decltype(pos), const Position *>);
+    }
+
+    // Test 3: Get component returns nullptr for missing/invalid
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        entity invalid = entity::invalid();
+
+        // Entity without the component
+        EXPECT_EQ(mgr.get_component<Position>(e), nullptr);
+
+        // Invalid entity handle
+        EXPECT_EQ(mgr.get_component<Position>(invalid), nullptr);
+    }
 }
 
-TEST_F(EntitiesTests, GetComponentConst)
-{
-    entity e = mgr.create();
-    mgr.add_component<Position>(e, Position{5.0f, 6.0f, 7.0f});
-
-    const entities &const_mgr = mgr;
-    const Position *pos = const_mgr.get_component<Position>(e);
-
-    EXPECT_NE(pos, nullptr);
-    EXPECT_EQ(pos->x, 5.0f);
-    static_assert(std::is_same_v<decltype(pos), const Position *>);
-}
-
-TEST_F(EntitiesTests, GetComponentNullptr)
-{
-    entity e = mgr.create();
-    entity invalid = entity::invalid();
-
-    // Entity without the component
-    EXPECT_EQ(mgr.get_component<Position>(e), nullptr);
-
-    // Invalid entity handle
-    EXPECT_EQ(mgr.get_component<Position>(invalid), nullptr);
-}
+//==============================================================================
+//                        Multi-Component Cleanup
+//==============================================================================
 
 TEST_F(EntitiesTests, DestroyRemovesAllComponents)
 {
@@ -260,5 +277,3 @@ TEST_F(EntitiesTests, Reserve)
     EXPECT_TRUE(mgr.valid(e));
     EXPECT_EQ(mgr.size(), 1);
 }
-
-

--- a/tests/entity/entity_tests.cpp
+++ b/tests/entity/entity_tests.cpp
@@ -28,42 +28,45 @@ protected:
 //                        Entity Creation and Validity
 //==============================================================================
 
-TEST_F(EntityTests, CreateValidEntity)
+TEST_F(EntityTests, CreationAndValidity)
 {
-    auto e = entity::create(42, 5);
+    // Test 1: Create valid entity
+    {
+        auto e = entity::create(42, 5);
 
-    EXPECT_EQ(e.id(), 42);
-    EXPECT_EQ(e.generation(), 5);
-    EXPECT_TRUE(e != entity::invalid());
-}
+        EXPECT_EQ(e.id(), 42);
+        EXPECT_EQ(e.generation(), 5);
+        EXPECT_TRUE(e != entity::invalid());
+    }
 
-TEST_F(EntityTests, CreateBoundaryValues)
-{
-    // Test maximum ID (1,048,574)
-    auto max_id_entity = entity::create(entity::MAX_ENTITIES, 0);
-    EXPECT_EQ(max_id_entity.id(), entity::MAX_ENTITIES);
-    EXPECT_EQ(max_id_entity.generation(), 0);
-    EXPECT_TRUE(max_id_entity != entity::invalid());
+    // Test 2: Boundary values
+    {
+        // Test maximum ID (1,048,574)
+        auto max_id_entity = entity::create(entity::MAX_ENTITIES, 0);
+        EXPECT_EQ(max_id_entity.id(), entity::MAX_ENTITIES);
+        EXPECT_EQ(max_id_entity.generation(), 0);
+        EXPECT_TRUE(max_id_entity != entity::invalid());
 
-    // Test maximum generation (4,094)
-    auto max_gen_entity = entity::create(0, entity::MAX_GENERATIONS);
-    EXPECT_EQ(max_gen_entity.id(), 0);
-    EXPECT_EQ(max_gen_entity.generation(), entity::MAX_GENERATIONS);
-    EXPECT_TRUE(max_gen_entity != entity::invalid());
+        // Test maximum generation (4,094)
+        auto max_gen_entity = entity::create(0, entity::MAX_GENERATIONS);
+        EXPECT_EQ(max_gen_entity.id(), 0);
+        EXPECT_EQ(max_gen_entity.generation(), entity::MAX_GENERATIONS);
+        EXPECT_TRUE(max_gen_entity != entity::invalid());
 
-    // Test both at max
-    auto max_both = entity::create(entity::MAX_ENTITIES, entity::MAX_GENERATIONS);
-    EXPECT_EQ(max_both.id(), entity::MAX_ENTITIES);
-    EXPECT_EQ(max_both.generation(), entity::MAX_GENERATIONS);
-    EXPECT_TRUE(max_both != entity::invalid());
-}
+        // Test both at max
+        auto max_both = entity::create(entity::MAX_ENTITIES, entity::MAX_GENERATIONS);
+        EXPECT_EQ(max_both.id(), entity::MAX_ENTITIES);
+        EXPECT_EQ(max_both.generation(), entity::MAX_GENERATIONS);
+        EXPECT_TRUE(max_both != entity::invalid());
+    }
 
-TEST_F(EntityTests, InvalidEntity)
-{
-    auto invalid = entity::invalid();
+    // Test 3: Invalid entity sentinel
+    {
+        auto invalid = entity::invalid();
 
-    EXPECT_TRUE(invalid == entity::invalid());
-    EXPECT_EQ(invalid, entity::invalid()); // Two invalid entities are equal
+        EXPECT_TRUE(invalid == entity::invalid());
+        EXPECT_EQ(invalid, entity::invalid()); // Two invalid entities are equal
+    }
 }
 
 //==============================================================================

--- a/tests/entity/extraction_tests.cpp
+++ b/tests/entity/extraction_tests.cpp
@@ -1,0 +1,407 @@
+#include <gtest/gtest.h>
+#include <gamecoe/entity/entities.hpp>
+#include <vector>
+#include <algorithm>
+
+using namespace gamecoe;
+
+//==============================================================================
+//                    Test Component Types
+//==============================================================================
+
+struct Transform
+{
+    float x, y, z;
+
+    bool operator==(const Transform &other) const
+    {
+        return x == other.x && y == other.y && z == other.z;
+    }
+};
+
+struct Velocity
+{
+    float dx, dy, dz;
+
+    bool operator==(const Velocity &other) const
+    {
+        return dx == other.dx && dy == other.dy && dz == other.dz;
+    }
+};
+
+struct Health
+{
+    int value;
+
+    bool operator==(const Health &other) const
+    {
+        return value == other.value;
+    }
+};
+
+//==============================================================================
+//                    ExtractionTests - Multi-component query tests
+//==============================================================================
+
+class ExtractionTests : public ::testing::Test
+{
+protected:
+    entities mgr;
+};
+
+//==============================================================================
+//                        Basic Extraction and Filtering
+//==============================================================================
+
+TEST_F(ExtractionTests, BasicExtractionAndFiltering)
+{
+    // Setup: Create entities with different component combinations
+    entity e1 = mgr.create();
+    mgr.add_component<Transform>(e1, Transform{1.0f, 0.0f, 0.0f});
+
+    entity e2 = mgr.create();
+    mgr.add_component<Velocity>(e2, Velocity{0.1f, 0.0f, 0.0f});
+
+    entity e3 = mgr.create();
+    mgr.add_component<Transform>(e3, Transform{3.0f, 0.0f, 0.0f});
+    mgr.add_component<Velocity>(e3, Velocity{0.3f, 0.0f, 0.0f});
+
+    entity e4 = mgr.create();
+    mgr.add_component<Transform>(e4, Transform{4.0f, 0.0f, 0.0f});
+    mgr.add_component<Velocity>(e4, Velocity{0.4f, 0.0f, 0.0f});
+
+    entity e5 = mgr.create();
+    mgr.add_component<Transform>(e5, Transform{5.0f, 0.0f, 0.0f});
+
+    // Test 1: Extract single component (Transform)
+    {
+        std::vector<entity> found_entities;
+        auto extracted = mgr.extract<Transform>();
+
+        for (auto [e, t] : extracted)
+        {
+            found_entities.push_back(e);
+        }
+
+        EXPECT_EQ(found_entities.size(), 4); // e1, e3, e4, e5
+        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e1) != found_entities.end());
+        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e3) != found_entities.end());
+        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e4) != found_entities.end());
+        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e5) != found_entities.end());
+    }
+
+    // Test 2: Extract single component (Velocity)
+    {
+        std::vector<entity> found_entities;
+        auto extracted = mgr.extract<Velocity>();
+
+        for (auto [e, v] : extracted)
+        {
+            found_entities.push_back(e);
+        }
+
+        EXPECT_EQ(found_entities.size(), 3); // e2, e3, e4
+        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e2) != found_entities.end());
+        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e3) != found_entities.end());
+        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e4) != found_entities.end());
+    }
+
+    // Test 3: Extract multiple components (Transform + Velocity)
+    {
+        std::vector<entity> found_entities;
+        auto extracted = mgr.extract<Transform, Velocity>();
+
+        for (auto [e, t, v] : extracted)
+        {
+            found_entities.push_back(e);
+            // Verify component values are correct
+            EXPECT_TRUE(mgr.has_component<Transform>(e));
+            EXPECT_TRUE(mgr.has_component<Velocity>(e));
+        }
+
+        EXPECT_EQ(found_entities.size(), 2); // Only e3 and e4
+        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e3) != found_entities.end());
+        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e4) != found_entities.end());
+    }
+
+    // Test 4: Verify component values can be read correctly
+    {
+        auto extracted = mgr.extract<Transform, Velocity>();
+        for (auto [e, t, v] : extracted)
+        {
+            if (e == e3)
+            {
+                EXPECT_EQ(t.x, 3.0f);
+                EXPECT_EQ(v.dx, 0.3f);
+            }
+            else if (e == e4)
+            {
+                EXPECT_EQ(t.x, 4.0f);
+                EXPECT_EQ(v.dx, 0.4f);
+            }
+        }
+    }
+
+    // Test 5: Verify component values can be modified
+    {
+        auto extracted = mgr.extract<Transform>();
+        for (auto [e, t] : extracted)
+        {
+            t.x += 100.0f;
+        }
+
+        // Verify modifications persisted
+        EXPECT_EQ(mgr.get_component<Transform>(e1)->x, 101.0f);
+        EXPECT_EQ(mgr.get_component<Transform>(e3)->x, 103.0f);
+        EXPECT_EQ(mgr.get_component<Transform>(e4)->x, 104.0f);
+        EXPECT_EQ(mgr.get_component<Transform>(e5)->x, 105.0f);
+    }
+}
+
+//==============================================================================
+//                        Empty and Edge Cases
+//==============================================================================
+
+TEST_F(ExtractionTests, EmptyAndEdgeCases)
+{
+    // Test 1: Empty entities manager
+    {
+        auto extracted = mgr.extract<Transform>();
+        EXPECT_EQ(extracted.begin(), extracted.end());
+
+        int count = 0;
+        for ([[maybe_unused]] auto [e, t] : extracted)
+        {
+            ++count;
+        }
+        EXPECT_EQ(count, 0);
+    }
+
+    // Test 2: Entities exist but none have the requested component
+    {
+        entity e1 = mgr.create();
+        entity e2 = mgr.create();
+        mgr.add_component<Transform>(e1, Transform{1.0f, 0.0f, 0.0f});
+        mgr.add_component<Transform>(e2, Transform{2.0f, 0.0f, 0.0f});
+
+        auto extracted = mgr.extract<Velocity>();
+        EXPECT_EQ(extracted.begin(), extracted.end());
+
+        int count = 0;
+        for ([[maybe_unused]] auto [e, v] : extracted)
+        {
+            ++count;
+        }
+        EXPECT_EQ(count, 0);
+    }
+
+    // Test 3: Request multiple components where no entity has all of them
+    {
+        mgr.clear();
+
+        entity e1 = mgr.create();
+        mgr.add_component<Transform>(e1, Transform{1.0f, 0.0f, 0.0f});
+
+        entity e2 = mgr.create();
+        mgr.add_component<Velocity>(e2, Velocity{0.1f, 0.0f, 0.0f});
+
+        entity e3 = mgr.create();
+        mgr.add_component<Health>(e3, Health{100});
+
+        // No entity has all three components
+        auto extracted = mgr.extract<Transform, Velocity, Health>();
+        EXPECT_EQ(extracted.begin(), extracted.end());
+
+        int count = 0;
+        for ([[maybe_unused]] auto [e, t, v, h] : extracted)
+        {
+            ++count;
+        }
+        EXPECT_EQ(count, 0);
+    }
+
+    // Test 4: Component type that was never added to any entity
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        mgr.add_component<Transform>(e, Transform{1.0f, 0.0f, 0.0f});
+
+        auto extracted = mgr.extract<Health>();
+        EXPECT_EQ(extracted.begin(), extracted.end());
+    }
+}
+
+//==============================================================================
+//                        Const Correctness
+//==============================================================================
+
+TEST_F(ExtractionTests, ConstCorrectness)
+{
+    entity e1 = mgr.create();
+    mgr.add_component<Transform>(e1, Transform{1.0f, 2.0f, 3.0f});
+    mgr.add_component<Velocity>(e1, Velocity{0.1f, 0.2f, 0.3f});
+
+    entity e2 = mgr.create();
+    mgr.add_component<Transform>(e2, Transform{4.0f, 5.0f, 6.0f});
+    mgr.add_component<Velocity>(e2, Velocity{0.4f, 0.5f, 0.6f});
+
+    // Test 1: Mixed const/mutable access
+    {
+        auto extracted = mgr.extract<Transform, const Velocity>();
+
+        for (auto [e, t, v] : extracted)
+        {
+            // Can modify Transform
+            t.x += 10.0f;
+
+            // Can read Velocity (const reference)
+            float speed = v.dx;
+            EXPECT_TRUE(speed >= 0.0f);
+
+            // Note: Uncommenting the line below should cause a compile error
+            // v.dx = 1.0f;  // Error: v is const Velocity&
+        }
+
+        // Verify Transform was modified
+        EXPECT_EQ(mgr.get_component<Transform>(e1)->x, 11.0f);
+        EXPECT_EQ(mgr.get_component<Transform>(e2)->x, 14.0f);
+
+        // Verify Velocity was not modified
+        EXPECT_EQ(mgr.get_component<Velocity>(e1)->dx, 0.1f);
+        EXPECT_EQ(mgr.get_component<Velocity>(e2)->dx, 0.4f);
+    }
+
+    // Test 2: Const entities manager forces const components
+    {
+        const entities &const_mgr = mgr;
+        auto extracted = const_mgr.extract<Transform>();
+
+        for (auto [e, t] : extracted)
+        {
+            // Can read Transform
+            float x = t.x;
+            EXPECT_TRUE(x >= 0.0f);
+
+            // Note: Uncommenting the line below should cause a compile error
+            // t.x = 99.0f;  // Error: t is const Transform&
+        }
+
+        // Verify type is const Transform&
+        static_assert(std::is_same_v<
+            decltype(const_mgr.extract<Transform>()),
+            extraction<const Transform>
+        >);
+    }
+
+    // Test 3: Const entities with multiple components
+    {
+        const entities &const_mgr = mgr;
+        auto extracted = const_mgr.extract<Transform, Velocity>();
+
+        int count = 0;
+        for (auto [e, t, v] : extracted)
+        {
+            // Can only read
+            EXPECT_TRUE(t.x >= 0.0f);
+            EXPECT_TRUE(v.dx >= 0.0f);
+            ++count;
+
+            // Note: These should cause compile errors
+            // t.x = 1.0f;  // Error: const Transform&
+            // v.dx = 1.0f; // Error: const Velocity&
+        }
+        EXPECT_EQ(count, 2);
+    }
+}
+
+//==============================================================================
+//                        Iterator Protocol
+//==============================================================================
+
+TEST_F(ExtractionTests, IteratorProtocol)
+{
+    // Setup
+    entity e1 = mgr.create();
+    mgr.add_component<Transform>(e1, Transform{1.0f, 0.0f, 0.0f});
+
+    entity e2 = mgr.create();
+    mgr.add_component<Transform>(e2, Transform{2.0f, 0.0f, 0.0f});
+
+    entity e3 = mgr.create();
+    mgr.add_component<Transform>(e3, Transform{3.0f, 0.0f, 0.0f});
+
+    auto extracted = mgr.extract<Transform>();
+
+    // Test 1: begin() != end() when entities exist
+    EXPECT_NE(extracted.begin(), extracted.end());
+
+    // Test 2: Prefix operator++ advances and returns reference
+    {
+        auto it = extracted.begin();
+        auto &ref = ++it;
+        EXPECT_EQ(&ref, &it); // Returns reference to self
+    }
+
+    // Test 3: Postfix operator++ advances and returns copy
+    {
+        auto it = extracted.begin();
+        auto copy = it++;
+        EXPECT_NE(it, copy); // Copy is different from advanced iterator
+    }
+
+    // Test 4: operator* returns correct tuple
+    {
+        auto it = extracted.begin();
+        auto [e, t] = *it;
+
+        EXPECT_TRUE(mgr.valid(e));
+        EXPECT_TRUE(mgr.has_component<Transform>(e));
+
+        // Verify we can use the types correctly
+        static_assert(std::is_same_v<decltype(e), entity>);
+        static_assert(std::is_same_v<decltype(t), Transform&>);
+    }
+
+    // Test 5: Iterator equality/inequality
+    {
+        auto it1 = extracted.begin();
+        auto it2 = extracted.begin();
+        auto it_end = extracted.end();
+
+        EXPECT_EQ(it1, it2);
+        EXPECT_NE(it1, it_end);
+    }
+
+    // Test 6: Range-for loop syntax works
+    {
+        std::vector<float> x_values;
+        for (auto [e, t] : extracted)
+        {
+            x_values.push_back(t.x);
+        }
+
+        EXPECT_EQ(x_values.size(), 3);
+        EXPECT_TRUE(std::find(x_values.begin(), x_values.end(), 1.0f) != x_values.end());
+        EXPECT_TRUE(std::find(x_values.begin(), x_values.end(), 2.0f) != x_values.end());
+        EXPECT_TRUE(std::find(x_values.begin(), x_values.end(), 3.0f) != x_values.end());
+    }
+
+    // Test 7: Manual iteration with begin/end
+    {
+        int count = 0;
+        for (auto it = extracted.begin(); it != extracted.end(); ++it)
+        {
+            auto [e, t] = *it;
+            EXPECT_TRUE(mgr.valid(e));
+            ++count;
+        }
+        EXPECT_EQ(count, 3);
+    }
+
+    // Test 8: Empty extraction has begin() == end()
+    {
+        mgr.clear();
+        auto empty_extracted = mgr.extract<Transform>();
+        EXPECT_EQ(empty_extracted.begin(), empty_extracted.end());
+    }
+}

--- a/tests/entity/sparse_set_tests.cpp
+++ b/tests/entity/sparse_set_tests.cpp
@@ -15,107 +15,166 @@ protected:
 };
 
 //==============================================================================
-//                        Basic Insert and Contains
+//                        Insert Operations
 //==============================================================================
 
-TEST_F(SparseSetTests, InsertSingleEntity)
+TEST_F(SparseSetTests, InsertOperations)
 {
-    auto e = entity::create(42, 0);
+    // Test 1: Insert single entity
+    {
+        auto e = entity::create(42, 0);
 
-    set.insert(e);
-
-    EXPECT_TRUE(set.contains(e));
-    EXPECT_EQ(set.size(), 1);
-    EXPECT_FALSE(set.empty());
-
-    auto index = set.index(e);
-    EXPECT_TRUE(index.has_value());
-    EXPECT_EQ(index.value(), 0);
-}
-
-TEST_F(SparseSetTests, InsertMultiple)
-{
-    std::vector<entity> entities;
-
-    // Insert 100 entities
-    for (std::uint32_t i = 0; i < 100; ++i)
-        entities.push_back(entity::create(i, 0));
-
-    for (auto e : entities)
         set.insert(e);
 
-    EXPECT_EQ(set.size(), 100);
-
-    // Verify all are contained
-    for (auto e : entities)
         EXPECT_TRUE(set.contains(e));
-}
+        EXPECT_EQ(set.size(), 1);
+        EXPECT_FALSE(set.empty());
 
-TEST_F(SparseSetTests, InsertDuplicate)
-{
-    auto e = entity::create(42, 0);
+        auto index = set.index(e);
+        EXPECT_TRUE(index.has_value());
+        EXPECT_EQ(index.value(), 0);
+    }
 
-    set.insert(e);
-    set.insert(e); // Duplicate insert
+    // Test 2: Insert multiple entities
+    {
+        set.clear();
+        std::vector<entity> entities;
 
-    EXPECT_EQ(set.size(), 1); // Size unchanged
-    EXPECT_TRUE(set.contains(e));
+        // Insert 100 entities
+        for (std::uint32_t i = 0; i < 100; ++i)
+            entities.push_back(entity::create(i, 0));
+
+        for (auto e : entities)
+            set.insert(e);
+
+        EXPECT_EQ(set.size(), 100);
+
+        // Verify all are contained
+        for (auto e : entities)
+            EXPECT_TRUE(set.contains(e));
+    }
+
+    // Test 3: Insert duplicate (no-op)
+    {
+        set.clear();
+        auto e = entity::create(42, 0);
+
+        set.insert(e);
+        set.insert(e); // Duplicate insert
+
+        EXPECT_EQ(set.size(), 1); // Size unchanged
+        EXPECT_TRUE(set.contains(e));
+    }
 }
 
 //==============================================================================
 //                        Erase Operations
 //==============================================================================
 
-TEST_F(SparseSetTests, EraseSingleEntity)
+TEST_F(SparseSetTests, EraseOperations)
 {
-    auto e = entity::create(42, 0);
+    // Test 1: Erase single entity
+    {
+        auto e = entity::create(42, 0);
 
-    set.insert(e);
-    set.erase(e);
+        set.insert(e);
+        set.erase(e);
 
-    EXPECT_FALSE(set.contains(e));
-    EXPECT_EQ(set.size(), 0);
-    EXPECT_TRUE(set.empty());
+        EXPECT_FALSE(set.contains(e));
+        EXPECT_EQ(set.size(), 0);
+        EXPECT_TRUE(set.empty());
 
-    auto index = set.index(e);
-    EXPECT_FALSE(index.has_value());
+        auto index = set.index(e);
+        EXPECT_FALSE(index.has_value());
+    }
+
+    // Test 2: Erase with swap-and-pop
+    {
+        set.clear();
+        auto e1 = entity::create(10, 0);
+        auto e2 = entity::create(20, 0);
+        auto e3 = entity::create(30, 0);
+
+        set.insert(e1);
+        set.insert(e2);
+        set.insert(e3);
+
+        // Erase middle entity (e2)
+        set.erase(e2);
+
+        EXPECT_EQ(set.size(), 2);
+        EXPECT_TRUE(set.contains(e1));
+        EXPECT_FALSE(set.contains(e2));
+        EXPECT_TRUE(set.contains(e3));
+
+        // e3 should have been swapped to e2's old position
+        EXPECT_EQ(set.index(e1).value(), 0);
+        EXPECT_EQ(set.index(e3).value(), 1); // e3 moved to index 1 (e2's old position)
+    }
+
+    // Test 3: Erase non-existent entity (no-op)
+    {
+        set.clear();
+        auto e1 = entity::create(10, 0);
+        auto e2 = entity::create(20, 0);
+
+        set.insert(e1);
+        EXPECT_EQ(set.size(), 1);
+
+        set.erase(e2); // e2 not in set
+
+        EXPECT_EQ(set.size(), 1); // Size unchanged
+        EXPECT_TRUE(set.contains(e1));
+    }
 }
 
-TEST_F(SparseSetTests, EraseSwapAndPop)
+//==============================================================================
+//                        Erase At (by dense index)
+//==============================================================================
+
+TEST_F(SparseSetTests, EraseAtOperations)
 {
-    auto e1 = entity::create(10, 0);
-    auto e2 = entity::create(20, 0);
-    auto e3 = entity::create(30, 0);
+    // Test 1: Erase at with swap-and-pop
+    {
+        auto e1 = entity::create(10, 0);
+        auto e2 = entity::create(20, 0);
+        auto e3 = entity::create(30, 0);
 
-    set.insert(e1);
-    set.insert(e2);
-    set.insert(e3);
+        set.insert(e1);
+        set.insert(e2);
+        set.insert(e3);
 
-    // Erase middle entity (e2)
-    set.erase(e2);
+        // Erase middle entity by index (e2 is at dense index 1)
+        set.erase_at(1);
 
-    EXPECT_EQ(set.size(), 2);
-    EXPECT_TRUE(set.contains(e1));
-    EXPECT_FALSE(set.contains(e2));
-    EXPECT_TRUE(set.contains(e3));
+        EXPECT_EQ(set.size(), 2);
+        EXPECT_TRUE(set.contains(e1));
+        EXPECT_FALSE(set.contains(e2));
+        EXPECT_TRUE(set.contains(e3));
 
-    // e3 should have been swapped to e2's old position
-    EXPECT_EQ(set.index(e1).value(), 0);
-    EXPECT_EQ(set.index(e3).value(), 1); // e3 moved to index 1 (e2's old position)
-}
+        // e3 should have been swapped to index 1 (e2's old position)
+        EXPECT_EQ(set.index(e1).value(), 0);
+        EXPECT_EQ(set.index(e3).value(), 1);
 
-TEST_F(SparseSetTests, EraseNonExistent)
-{
-    auto e1 = entity::create(10, 0);
-    auto e2 = entity::create(20, 0);
+        // Erase last element by index (no swap needed)
+        set.erase_at(1); // e3 is now at index 1 (last)
 
-    set.insert(e1);
-    EXPECT_EQ(set.size(), 1);
+        EXPECT_EQ(set.size(), 1);
+        EXPECT_TRUE(set.contains(e1));
+        EXPECT_FALSE(set.contains(e3));
+    }
 
-    set.erase(e2); // e2 not in set
+    // Test 2: Erase at out of bounds (no-op)
+    {
+        set.clear();
+        auto e = entity::create(42, 0);
+        set.insert(e);
 
-    EXPECT_EQ(set.size(), 1); // Size unchanged
-    EXPECT_TRUE(set.contains(e1));
+        set.erase_at(5); // Out of bounds, should be no-op
+
+        EXPECT_EQ(set.size(), 1);
+        EXPECT_TRUE(set.contains(e));
+    }
 }
 
 //==============================================================================
@@ -239,51 +298,6 @@ TEST_F(SparseSetTests, MoveSemantics)
     EXPECT_EQ(set3.size(), 2);
     EXPECT_TRUE(set3.contains(e1));
     EXPECT_TRUE(set3.contains(e2));
-}
-
-//==============================================================================
-//                        Erase At (by dense index)
-//==============================================================================
-
-TEST_F(SparseSetTests, EraseAtSwapAndPop)
-{
-    auto e1 = entity::create(10, 0);
-    auto e2 = entity::create(20, 0);
-    auto e3 = entity::create(30, 0);
-
-    set.insert(e1);
-    set.insert(e2);
-    set.insert(e3);
-
-    // Erase middle entity by index (e2 is at dense index 1)
-    set.erase_at(1);
-
-    EXPECT_EQ(set.size(), 2);
-    EXPECT_TRUE(set.contains(e1));
-    EXPECT_FALSE(set.contains(e2));
-    EXPECT_TRUE(set.contains(e3));
-
-    // e3 should have been swapped to index 1 (e2's old position)
-    EXPECT_EQ(set.index(e1).value(), 0);
-    EXPECT_EQ(set.index(e3).value(), 1);
-
-    // Erase last element by index (no swap needed)
-    set.erase_at(1); // e3 is now at index 1 (last)
-
-    EXPECT_EQ(set.size(), 1);
-    EXPECT_TRUE(set.contains(e1));
-    EXPECT_FALSE(set.contains(e3));
-}
-
-TEST_F(SparseSetTests, EraseAtOutOfBounds)
-{
-    auto e = entity::create(42, 0);
-    set.insert(e);
-
-    set.erase_at(5); // Out of bounds, should be no-op
-
-    EXPECT_EQ(set.size(), 1);
-    EXPECT_TRUE(set.contains(e));
 }
 
 //==============================================================================


### PR DESCRIPTION
- Implement extraction<Components...> templated class with lazy iterator-based queries
- Add fold expressions for runtime tuple access and component filtering
- Support mixed const/mutable component access
- Integrate entities::extract() with mutable and const overloads
- Add get_entity_at_index() to component_pool for iteration support
- Add comprehensive extraction test suite
- Consolidate all ECS test suites to consistent style (45 -> 30 tests)