### PR TITLE
[Feature]: Implement shape_renderer and render_order components

### DIFF
--- a/include/gamecoe/component/render_order.hpp
+++ b/include/gamecoe/component/render_order.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+namespace gamecoe
+{
+    namespace components
+    {
+        struct render_order
+        {
+            std::int8_t layer = 0;
+        };
+
+        static_assert(std::is_standard_layout_v<render_order>);
+    } // namespace components
+} // namespace gamecoe

--- a/include/gamecoe/component/shape_renderer.hpp
+++ b/include/gamecoe/component/shape_renderer.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <gamecoe/utils/shape.hpp>
+#include <colorcoe.hpp>
+#include <type_traits>
+
+namespace gamecoe
+{
+    namespace components
+    {
+        struct shape_renderer
+        {
+            shape kind = shape::invalid;
+            Color color;
+
+            static shape_renderer triangle(const Color &color) { return { shape::triangle, color }; }
+            static shape_renderer rectangle(const Color &color) { return { shape::rectangle, color }; }
+            static shape_renderer box(const Color &color) { return { shape::box, color }; }
+            static shape_renderer circle(const Color &color) { return { shape::circle, color }; }
+            static shape_renderer sphere(const Color &color) { return { shape::sphere, color }; }
+        };
+
+        static_assert(std::is_standard_layout_v<shape_renderer>);
+    } // namespace components
+} // namespace gamecoe

--- a/include/gamecoe/utils/shape.hpp
+++ b/include/gamecoe/utils/shape.hpp
@@ -2,14 +2,14 @@
 
 namespace gamecoe
 {
-    enum class Shape
+    enum class shape
     {
-        Invalid,
-        Triangle,
-        Rectangle,
-        Box,
-        Circle,
-        Sphere,
+        invalid,
+        triangle,
+        rectangle,
+        box,
+        circle,
+        sphere,
         // TODO: Support more primitive shapes
     };
 } // namespace gamecoe

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(gamecoe_tests
     entity/extraction_tests.cpp
     component/transform_tests.cpp
     component/parent_child_tests.cpp
+    component/shape_renderer_tests.cpp
 )
 
 target_link_libraries(gamecoe_tests

--- a/tests/component/shape_renderer_tests.cpp
+++ b/tests/component/shape_renderer_tests.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include <gamecoe/component/shape_renderer.hpp>
+#include <colorcoe.hpp>
+
+using namespace gamecoe;
+
+//==============================================================================
+//              ShapeRendererTests - shape_renderer component tests
+//==============================================================================
+
+class ShapeRendererTests : public ::testing::Test
+{
+protected:
+    components::shape_renderer sr;
+};
+
+//==============================================================================
+//                        Default State
+//==============================================================================
+
+TEST_F(ShapeRendererTests, DefaultState)
+{
+    // Test 1: Default-constructed shape_renderer has invalid kind and default (black) color
+    {
+        EXPECT_EQ(sr.kind, shape::invalid);
+        EXPECT_EQ(sr.color, Color());
+    }
+}
+
+//==============================================================================
+//                        Factory Functions
+//==============================================================================
+
+TEST_F(ShapeRendererTests, FactoryFunctions)
+{
+    // Test 1: triangle() produces the correct kind and color
+    {
+        auto s = components::shape_renderer::triangle(colorcoe::red());
+        EXPECT_EQ(s.kind, shape::triangle);
+        EXPECT_EQ(s.color, colorcoe::red());
+    }
+
+    // Test 2: rectangle() produces the correct kind and color
+    {
+        auto s = components::shape_renderer::rectangle(colorcoe::green());
+        EXPECT_EQ(s.kind, shape::rectangle);
+        EXPECT_EQ(s.color, colorcoe::green());
+    }
+
+    // Test 3: box() produces the correct kind and color
+    {
+        auto s = components::shape_renderer::box(colorcoe::blue());
+        EXPECT_EQ(s.kind, shape::box);
+        EXPECT_EQ(s.color, colorcoe::blue());
+    }
+
+    // Test 4: circle() produces the correct kind and color
+    {
+        auto s = components::shape_renderer::circle(colorcoe::yellow());
+        EXPECT_EQ(s.kind, shape::circle);
+        EXPECT_EQ(s.color, colorcoe::yellow());
+    }
+
+    // Test 5: sphere() produces the correct kind and color
+    {
+        auto s = components::shape_renderer::sphere(colorcoe::white());
+        EXPECT_EQ(s.kind, shape::sphere);
+        EXPECT_EQ(s.color, colorcoe::white());
+    }
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -19,6 +19,7 @@ int printHelp()
     std::cout << "  TransformTests           - Transform component tests" << std::endl;
     std::cout << "  ParentTests              - Parent component tests" << std::endl;
     std::cout << "  ChildrenTests            - Children component tests" << std::endl;
+    std::cout << "  ShapeRendererTests       - Shape renderer component tests" << std::endl;
     std::cout << std::endl;
     std::cout << "Example usage:" << std::endl;
     std::cout << "  ./gamecoe_tests --suite=EntityTests" << std::endl;
@@ -34,7 +35,7 @@ int main(int argc, char **argv)
     std::cout << std::endl;
     std::cout << "Comprehensive testing for gamecoe." << std::endl;
     std::cout << "Testing Entity Module: entity, sparse_set, component_pool, entities" << std::endl;
-    std::cout << "Testing Component Module: transform, parent, children" << std::endl;
+    std::cout << "Testing Component Module: transform, parent, children, shape_renderer" << std::endl;
     std::cout << std::endl;
 
     testcoe::init(&argc, argv);


### PR DESCRIPTION
Replaces the original polymorphic Renderer hierarchy with plain POD components,
shape_renderer covers all primitive shapes via a single shape+Color struct with factory functions, and render_order is a
separate opt-in component for draw-order layering so entities on the default layer pay no memory cost.

- Rename Shape enum to snake_case (shape)
- Add shape_renderer POD component (unified across all primitive shapes) with factory functions for each shape (triangle, rectangle, box, circle, sphere)
- Add render_order POD component for opt-in draw-order layering
- Add shape_renderer unit tests and wire them into the test suite