### PR TITLE
[Feature]: Implement basic collider components

### DIFF
--- a/include/gamecoe/component/collision_callbacks.hpp
+++ b/include/gamecoe/component/collision_callbacks.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <type_traits>
+
+namespace gamecoe
+{
+    struct entity;
+    class entities;
+
+    namespace components
+    {
+        using collision_callback = void(*)(entity self, entities& self_registry, entity other, entities& other_registry);
+
+        struct collision_callbacks
+        {
+            collision_callback on_begin = nullptr;
+            collision_callback on_continuous = nullptr;
+            collision_callback on_end = nullptr;
+        };
+
+        static_assert(std::is_standard_layout_v<collision_callbacks>);
+    } // namespace components
+} // namespace gamecoe

--- a/include/gamecoe/component/collision_layer.hpp
+++ b/include/gamecoe/component/collision_layer.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+namespace gamecoe
+{
+    namespace components
+    {
+        struct collision_layer
+        {
+            std::int8_t layer = 0;
+        };
+
+        static_assert(std::is_standard_layout_v<collision_layer>);
+    } // namespace components
+} // namespace gamecoe

--- a/include/gamecoe/component/shape_collider.hpp
+++ b/include/gamecoe/component/shape_collider.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <gamecoe/utils/shape.hpp>
+#include <type_traits>
+
+namespace gamecoe
+{
+    namespace components
+    {
+        struct shape_collider
+        {
+            shape kind = shape::invalid;
+
+            static shape_collider triangle() { return { shape::triangle }; }
+            static shape_collider rectangle() { return { shape::rectangle }; }
+            static shape_collider box() { return { shape::box }; }
+            static shape_collider circle() { return { shape::circle }; }
+            static shape_collider sphere() { return { shape::sphere }; }
+        };
+
+        static_assert(std::is_standard_layout_v<shape_collider>);
+    } // namespace components
+} // namespace gamecoe

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(gamecoe_tests
     component/transform_tests.cpp
     component/parent_child_tests.cpp
     component/shape_renderer_tests.cpp
+    component/shape_collider_tests.cpp
 )
 
 target_link_libraries(gamecoe_tests

--- a/tests/component/shape_collider_tests.cpp
+++ b/tests/component/shape_collider_tests.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+#include <gamecoe/component/shape_collider.hpp>
+
+using namespace gamecoe;
+
+//==============================================================================
+//              ShapeColliderTests - shape_collider component tests
+//==============================================================================
+
+class ShapeColliderTests : public ::testing::Test
+{
+protected:
+    components::shape_collider sc;
+};
+
+//==============================================================================
+//                        Default State
+//==============================================================================
+
+TEST_F(ShapeColliderTests, DefaultState)
+{
+    // Test 1: Default-constructed shape_collider has invalid kind
+    {
+        EXPECT_EQ(sc.kind, shape::invalid);
+    }
+}
+
+//==============================================================================
+//                        Factory Functions
+//==============================================================================
+
+TEST_F(ShapeColliderTests, FactoryFunctions)
+{
+    // Test 1: triangle() produces the correct kind
+    {
+        auto s = components::shape_collider::triangle();
+        EXPECT_EQ(s.kind, shape::triangle);
+    }
+
+    // Test 2: rectangle() produces the correct kind
+    {
+        auto s = components::shape_collider::rectangle();
+        EXPECT_EQ(s.kind, shape::rectangle);
+    }
+
+    // Test 3: box() produces the correct kind
+    {
+        auto s = components::shape_collider::box();
+        EXPECT_EQ(s.kind, shape::box);
+    }
+
+    // Test 4: circle() produces the correct kind
+    {
+        auto s = components::shape_collider::circle();
+        EXPECT_EQ(s.kind, shape::circle);
+    }
+
+    // Test 5: sphere() produces the correct kind
+    {
+        auto s = components::shape_collider::sphere();
+        EXPECT_EQ(s.kind, shape::sphere);
+    }
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -20,6 +20,7 @@ int printHelp()
     std::cout << "  ParentTests              - Parent component tests" << std::endl;
     std::cout << "  ChildrenTests            - Children component tests" << std::endl;
     std::cout << "  ShapeRendererTests       - Shape renderer component tests" << std::endl;
+    std::cout << "  ShapeColliderTests       - Shape collider component tests" << std::endl;
     std::cout << std::endl;
     std::cout << "Example usage:" << std::endl;
     std::cout << "  ./gamecoe_tests --suite=EntityTests" << std::endl;
@@ -35,7 +36,7 @@ int main(int argc, char **argv)
     std::cout << std::endl;
     std::cout << "Comprehensive testing for gamecoe." << std::endl;
     std::cout << "Testing Entity Module: entity, sparse_set, component_pool, entities" << std::endl;
-    std::cout << "Testing Component Module: transform, parent, children, shape_renderer" << std::endl;
+    std::cout << "Testing Component Module: transform, parent, children, shape_renderer, shape_collider" << std::endl;
     std::cout << std::endl;
 
     testcoe::init(&argc, argv);


### PR DESCRIPTION
Adds the remaining collider-side POD components for the DoD ECS refactor: shape_collider, collision_layer, and collision_callbacks.

- Add shape_collider POD component with a shape-only kind field and per-shape factory functions (triangle/rectangle/box/circle/sphere)
- Add collision_layer POD component for collision filtering, a separate axis from render_order's draw-order layer
- Add collision_callbacks POD component with on_begin/on_continuous/on_end function-pointer callbacks taking both entities' owning registries so the signature stays valid under any future cross-scene storage model
- Add shape_collider unit tests covering default construction and all five factory functions
- Wire shape_collider_tests.cpp into tests/CMakeLists.txt and tests/main.cpp