### PR TITLE
[Feature]: Implement command_buffer

### DIFF
--- a/include/gamecoe/component/scene_tag.hpp
+++ b/include/gamecoe/component/scene_tag.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <gamecoe/core/scene_id.hpp>
+#include <type_traits>
+
+namespace gamecoe
+{
+    namespace components
+    {
+        struct scene_tag
+        {
+            scene_id id{};
+        };
+
+        static_assert(std::is_standard_layout_v<scene_tag>);
+    } // namespace components
+} // namespace gamecoe

--- a/include/gamecoe/core/scene_id.hpp
+++ b/include/gamecoe/core/scene_id.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+
+namespace gamecoe
+{
+    // Opaque forward declaration
+    // fixed underlying type keeps this complete for storage, comparison, and pass-by-value with no enumerators needed.
+    // gencoe generates the concrete enum body into the game project, extending namespace gamecoe.
+    enum class scene_id : std::uint16_t;
+} // namespace gamecoe

--- a/include/gamecoe/entity/command_buffer.hpp
+++ b/include/gamecoe/entity/command_buffer.hpp
@@ -38,6 +38,8 @@ namespace gamecoe
         };
     
     private:
+        // std::function requires copyable captured values (all current components qualify) -
+        // revisit std::move_only_function once CI toolchains confirm C++23 library support
         using command = std::function<void(entities&, const resolver&)>;
         std::vector<components::transform> m_spawn_transforms;
         std::vector<command> m_commands;

--- a/include/gamecoe/entity/command_buffer.hpp
+++ b/include/gamecoe/entity/command_buffer.hpp
@@ -88,6 +88,9 @@ namespace gamecoe
             });
         }
 
+        // Queues a set_parent, applied at flush() via the live entities::set_parent().
+        void set_parent(placeholder child, placeholder parent);
+
         // Creates all queued entities, runs all queued commands, then clears. Stamps scene_tag on every created entity if `scene` is set.
         void flush(entities& ents, std::optional<scene_id> scene = std::nullopt);
 

--- a/include/gamecoe/entity/command_buffer.hpp
+++ b/include/gamecoe/entity/command_buffer.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <gamecoe/entity/entity.hpp>
+#include <gamecoe/entity/entities.hpp>
+#include <gamecoe/component/transform.hpp>
+#include <gamecoe/component/parent_child.hpp>
+#include <gamecoe/core/scene_id.hpp>
+#include <functional>
+#include <optional>
+#include <vector>
+#include <cstdint>
+#include <type_traits>
+#include <cassert>
+
+namespace gamecoe
+{
+    // Defers entity creation until flush() for building a scene async on a different thread. 
+    // Placeholders from spawn() are invalidated by their buffer's own flush() - don't reuse them after.
+    class command_buffer
+    {
+    public:
+        struct placeholder
+        {
+        private:
+            std::uint32_t m_index;
+            explicit constexpr placeholder(std::uint32_t index) noexcept : m_index(index) { }
+            friend class command_buffer;
+        };
+
+        class resolver
+        {
+            explicit resolver(const std::vector<entity>& created) noexcept : m_created(created) { }
+            const std::vector<entity>& m_created;
+            friend class command_buffer;
+
+        public:
+            entity resolve(placeholder p) const;
+        };
+
+        // Queues an entity with the given transform (default if omitted). No real entity until flush().
+        placeholder spawn(components::transform t = components::transform{});
+
+        // Queues a component add-or-assign, applied at flush().
+        template <typename T>
+        requires (!std::invocable<T, const resolver&>)
+        void add(placeholder p, T value)
+        {
+            static_assert(!std::is_same_v<T, components::parent> && !std::is_same_v<T, components::children>,
+                "command_buffer::add(): hierarchy components are managed - use command_buffer::set_parent() instead");
+
+            m_commands.emplace_back([p, value = std::move(value)](entities& ents, const resolver& r) mutable
+            {
+                entity e = r.resolve(p);
+                if (T* c = ents.get_component<T>(e)) *c = std::move(value);
+                else ents.add_component<T>(e, std::move(value));
+            });
+        }
+
+        // Creates all queued entities, runs all queued commands, then clears. Stamps scene_tag on every created entity if `scene` is set.
+        void flush(entities& ents, std::optional<scene_id> scene = std::nullopt);
+
+        std::size_t spawn_count() const noexcept { return m_spawn_transforms.size(); }
+        bool empty() const noexcept { return m_spawn_transforms.empty() && m_commands.empty(); }
+        void clear();
+
+    private:
+        using command = std::function<void(entities&, const resolver&)>;
+        std::vector<components::transform> m_spawn_transforms;
+        std::vector<command> m_commands;
+    };
+} // namespace gamecoe

--- a/include/gamecoe/entity/command_buffer.hpp
+++ b/include/gamecoe/entity/command_buffer.hpp
@@ -45,7 +45,7 @@ namespace gamecoe
         template <typename T>
         static void apply(entities& ents, entity e, T value)
         {
-            static_assert(!std::is_same_v<T, components::parent> && !std::is_same_v<T, components::children>,
+            static_assert(!hierarchy_component<T>,
                 "command_buffer::add(): hierarchy components are managed - use command_buffer::set_parent() instead");
 
             if constexpr (std::is_same_v<T, components::transform>)

--- a/include/gamecoe/entity/command_buffer.hpp
+++ b/include/gamecoe/entity/command_buffer.hpp
@@ -18,7 +18,7 @@ namespace gamecoe
     // Placeholders from spawn() are invalidated by their buffer's own flush() - don't reuse them after.
     class command_buffer
     {
-    public:
+    public: // internal structs/classes
         struct placeholder
         {
         private:
@@ -36,7 +36,28 @@ namespace gamecoe
         public:
             entity resolve(placeholder p) const;
         };
+    
+    private:
+        using command = std::function<void(entities&, const resolver&)>;
+        std::vector<components::transform> m_spawn_transforms;
+        std::vector<command> m_commands;
 
+        template <typename T>
+        static void apply(entities& ents, entity e, T value)
+        {
+            static_assert(!std::is_same_v<T, components::parent> && !std::is_same_v<T, components::children>,
+                "command_buffer::add(): hierarchy components are managed - use command_buffer::set_parent() instead");
+
+            if constexpr (std::is_same_v<T, components::transform>)
+                ents.transform(e) = std::move(value);
+            else
+            {
+                if (T* c = ents.get_component<T>(e)) *c = std::move(value);
+                else ents.add_component<T>(e, std::move(value));
+            }
+        }
+    
+    public:
         // Queues an entity with the given transform (default if omitted). No real entity until flush().
         placeholder spawn(components::transform t = components::transform{});
 
@@ -45,14 +66,25 @@ namespace gamecoe
         requires (!std::invocable<T, const resolver&>)
         void add(placeholder p, T value)
         {
-            static_assert(!std::is_same_v<T, components::parent> && !std::is_same_v<T, components::children>,
-                "command_buffer::add(): hierarchy components are managed - use command_buffer::set_parent() instead");
-
             m_commands.emplace_back([p, value = std::move(value)](entities& ents, const resolver& r) mutable
             {
                 entity e = r.resolve(p);
-                if (T* c = ents.get_component<T>(e)) *c = std::move(value);
-                else ents.add_component<T>(e, std::move(value));
+                apply<T>(ents, e, std::move(value));
+            });
+        }
+
+        // Queues a component computed from a resolver callable, applied at flush().
+        template <typename Callable>
+        requires std::invocable<Callable, const resolver&>
+        void add(placeholder p, Callable&& fn)
+        {
+            using T = std::decay_t<std::invoke_result_t<Callable, const resolver&>>;
+            static_assert(!std::is_void_v<T>, "command_buffer::add(): callable must return a component value");
+
+            m_commands.emplace_back([p, fn = std::forward<Callable>(fn)](entities& ents, const resolver& r) mutable
+            {
+                entity e = r.resolve(p);
+                apply<T>(ents, e, fn(r));
             });
         }
 
@@ -62,10 +94,5 @@ namespace gamecoe
         std::size_t spawn_count() const noexcept { return m_spawn_transforms.size(); }
         bool empty() const noexcept { return m_spawn_transforms.empty() && m_commands.empty(); }
         void clear();
-
-    private:
-        using command = std::function<void(entities&, const resolver&)>;
-        std::vector<components::transform> m_spawn_transforms;
-        std::vector<command> m_commands;
     };
 } // namespace gamecoe

--- a/include/gamecoe/entity/component_pool.hpp
+++ b/include/gamecoe/entity/component_pool.hpp
@@ -71,10 +71,13 @@ namespace gamecoe
         template <typename... Args>
         T& add(entity e, Args&&... args)
         {
-            if(contains(e)) 
+            if (contains(e))
             {
                 assert(false && "component_pool::add(): entity already has this component");
-                return m_components[m_entities.index(e).value()];
+                // overwriting with the new value on release build mode
+                T &existing = m_components[m_entities.index(e).value()];
+                existing = T(std::forward<Args>(args)...);
+                return existing;
             }
 
             m_entities.insert(e);

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -13,6 +13,13 @@
 
 namespace gamecoe
 {
+    namespace components
+    {
+        struct transform;
+        struct parent;
+        struct children;
+    } // namespace components
+
     class entities
     {
         static std::uint32_t s_component_id;
@@ -74,6 +81,11 @@ namespace gamecoe
         template <typename T, typename... Args>
         T& add_component(entity e, Args&&... args)
         {
+            static_assert(!std::is_same_v<T, components::transform>,
+                "entities::add_component(): transform is mandatory, added automatically by create()");
+            static_assert(!std::is_same_v<T, components::parent> && !std::is_same_v<T, components::children>,
+                "entities::add_component(): hierarchy components are managed - use entities::set_parent() instead");
+
             assert(valid(e) && "entities::add_component(): entity is not valid");
 
             auto pool = get_pool<T>();
@@ -96,6 +108,11 @@ namespace gamecoe
         template <typename T>
         void remove_component(entity e)
         {
+            static_assert(!std::is_same_v<T, components::transform>,
+                "entities::remove_component(): transform is mandatory and cannot be removed");
+            static_assert(!std::is_same_v<T, components::parent> && !std::is_same_v<T, components::children>,
+                "entities::remove_component(): hierarchy components are managed - use entities::remove_parent() instead");
+
             if (!has_component<T>(e)) return;
 
             m_pools[component_id<T>()]->remove(e);
@@ -122,6 +139,12 @@ namespace gamecoe
             auto pool = static_cast<const component_pool<T>*>(m_pools[component_id<T>()].get());
             return &(pool->get(e));
         }
+
+        // Direct accessor for the mandatory transform component
+        components::transform& transform(entity e);
+
+        // Direct accessor for the mandatory transform component
+        const components::transform& transform(entity e) const;
 
         // Iterates over all entities and their components and run func() on each of them
         template <typename T, typename Func>

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -146,6 +146,15 @@ namespace gamecoe
         // Direct accessor for the mandatory transform component
         const components::transform& transform(entity e) const;
 
+        // Sets child's parent, updating both sides.
+        void set_parent(entity child, entity parent);
+
+        // Removes child's parent link, updating both sides.
+        void remove_parent(entity child);
+
+        // Removes all of the entity's children, updating both sides.
+        void remove_children(entity parent);
+
         // Iterates over all entities and their components and run func() on each of them
         template <typename T, typename Func>
         void for_each(Func &&func)

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -20,6 +20,10 @@ namespace gamecoe
         struct children;
     } // namespace components
 
+    // True for the hierarchy-managed relationship components - see entities::set_parent()/remove_parent()
+    template <typename T>
+    concept hierarchy_component = std::is_same_v<T, components::parent> || std::is_same_v<T, components::children>;
+
     class entities
     {
         static std::uint32_t s_component_id;
@@ -83,7 +87,7 @@ namespace gamecoe
         {
             static_assert(!std::is_same_v<T, components::transform>,
                 "entities::add_component(): transform is mandatory, added automatically by create()");
-            static_assert(!std::is_same_v<T, components::parent> && !std::is_same_v<T, components::children>,
+            static_assert(!hierarchy_component<T>,
                 "entities::add_component(): hierarchy components are managed - use entities::set_parent() instead");
 
             assert(valid(e) && "entities::add_component(): entity is not valid");
@@ -110,7 +114,7 @@ namespace gamecoe
         {
             static_assert(!std::is_same_v<T, components::transform>,
                 "entities::remove_component(): transform is mandatory and cannot be removed");
-            static_assert(!std::is_same_v<T, components::parent> && !std::is_same_v<T, components::children>,
+            static_assert(!hierarchy_component<T>,
                 "entities::remove_component(): hierarchy components are managed - use entities::remove_parent() instead");
 
             if (!has_component<T>(e)) return;

--- a/src/gamecoe/entity/command_buffer.cpp
+++ b/src/gamecoe/entity/command_buffer.cpp
@@ -1,0 +1,44 @@
+#include <gamecoe/entity/command_buffer.hpp>
+#include <gamecoe/component/scene_tag.hpp>
+#include <cassert>
+
+namespace gamecoe
+{
+    command_buffer::placeholder command_buffer::spawn(components::transform t)
+    {
+        m_spawn_transforms.push_back(t);
+        return placeholder(static_cast<std::uint32_t>(m_spawn_transforms.size() - 1));
+    }
+
+    entity command_buffer::resolver::resolve(placeholder p) const
+    {
+        assert(p.m_index < m_created.size() && "command_buffer::resolver::resolve(): placeholder out of range");
+        return m_created[p.m_index];
+    }
+
+    void command_buffer::flush(entities& ents, std::optional<scene_id> scene)
+    {
+        std::vector<entity> created;
+        created.reserve(m_spawn_transforms.size());
+
+        for (const components::transform& t : m_spawn_transforms)
+        {
+            entity e = ents.create();
+            ents.transform(e) = t;
+            if (scene) ents.add_component<components::scene_tag>(e, components::scene_tag{ *scene });
+            created.push_back(e);
+        }
+
+        resolver r(created);
+        for (auto& cmd : m_commands)
+            cmd(ents, r);
+
+        clear();
+    }
+
+    void command_buffer::clear()
+    {
+        m_spawn_transforms.clear();
+        m_commands.clear();
+    }
+} // namespace gamecoe

--- a/src/gamecoe/entity/command_buffer.cpp
+++ b/src/gamecoe/entity/command_buffer.cpp
@@ -16,6 +16,14 @@ namespace gamecoe
         return m_created[p.m_index];
     }
 
+    void command_buffer::set_parent(placeholder child, placeholder parent)
+    {
+        m_commands.emplace_back([child, parent](entities& ents, const resolver& r)
+        {
+            ents.set_parent(r.resolve(child), r.resolve(parent));
+        });
+    }
+
     void command_buffer::flush(entities& ents, std::optional<scene_id> scene)
     {
         std::vector<entity> created;

--- a/src/gamecoe/entity/entities.cpp
+++ b/src/gamecoe/entity/entities.cpp
@@ -1,4 +1,5 @@
 #include <gamecoe/entity/entities.hpp>
+#include <gamecoe/component/transform.hpp>
 #include <cassert>
 #include <cstddef>
 
@@ -26,7 +27,26 @@ namespace gamecoe
             generation = m_generations[id];
         }
 
-        return entity::create(id, generation);
+        entity e = entity::create(id, generation);
+        get_pool<components::transform>()->add(e);
+
+        return e;
+    }
+
+    components::transform& entities::transform(entity e)
+    {
+        assert(valid(e) && "entities::transform(): entity is not valid");
+        components::transform* t = get_component<components::transform>(e);
+        assert(t && "entities::transform(): transform missing (should be impossible - mandatory component)");
+        return *t;
+    }
+
+    const components::transform& entities::transform(entity e) const
+    {
+        assert(valid(e) && "entities::transform(): entity is not valid");
+        const components::transform* t = get_component<components::transform>(e);
+        assert(t && "entities::transform(): transform missing (should be impossible - mandatory component)");
+        return *t;
     }
 
     void entities::destroy(entity e)

--- a/src/gamecoe/entity/entities.cpp
+++ b/src/gamecoe/entity/entities.cpp
@@ -1,5 +1,6 @@
 #include <gamecoe/entity/entities.hpp>
 #include <gamecoe/component/transform.hpp>
+#include <gamecoe/component/parent_child.hpp>
 #include <cassert>
 #include <cstddef>
 
@@ -53,10 +54,20 @@ namespace gamecoe
     {
         if (!valid(e)) return;
 
-        for (auto &pool : m_pools) if (pool) pool->remove(e);
+        remove_parent(e);
+
+        auto children_pool = get_pool<components::children>();
+        std::vector<entity> children_to_destroy;
+        if (children_pool->contains(e))
+            children_to_destroy = children_pool->get(e).handles;
 
         m_generations[e.id()]++;
         m_recycle_ids.push_back(e.id());
+
+        for (entity child : children_to_destroy)
+            if (valid(child)) destroy(child);
+
+        for (auto &pool : m_pools) if (pool) pool->remove(e);
     }
 
     void entities::clear()
@@ -84,6 +95,78 @@ namespace gamecoe
     {
         assert(static_cast<std::size_t>(m_current_entity_id) >= m_recycle_ids.size());
         return static_cast<std::size_t>(m_current_entity_id) - m_recycle_ids.size();
+    }
+
+    void entities::set_parent(entity child, entity parent)
+    {
+        assert(valid(child) && valid(parent) && "entities::set_parent(): child/parent must be valid entities");
+        assert(child != parent && "entities::set_parent(): entity cannot be its own parent");
+
+        auto parent_pool = get_pool<components::parent>();
+        auto children_pool = get_pool<components::children>();
+
+        bool has_old = parent_pool->contains(child);
+        entity old_parent = has_old ? parent_pool->get(child).handle : entity::invalid();
+
+        if (has_old && old_parent == parent) return;
+
+        entity ancestor = parent;
+        std::size_t guard = 0;
+        while (guard < size())
+        {
+            assert(ancestor != child && "entities::set_parent(): would create a parent/child cycle");
+            if (!parent_pool->contains(ancestor)) break;
+            ancestor = parent_pool->get(ancestor).handle;
+            ++guard;
+        }
+
+        if (has_old)
+        {
+            if (children_pool->contains(old_parent))
+            {
+                auto& handles = children_pool->get(old_parent).handles;
+                std::erase(handles, child);
+                if (handles.empty()) children_pool->remove(old_parent);
+            }
+        }
+
+        if (has_old) parent_pool->get(child).handle = parent;
+        else parent_pool->add(child, components::parent{ parent });
+
+        if (children_pool->contains(parent)) children_pool->get(parent).handles.push_back(child);
+        else children_pool->add(parent, components::children{ { child } });
+    }
+
+    void entities::remove_parent(entity child)
+    {
+        auto parent_pool = get_pool<components::parent>();
+        if (!parent_pool->contains(child)) return;
+
+        entity old_parent = parent_pool->get(child).handle;
+
+        auto children_pool = get_pool<components::children>();
+        if (children_pool->contains(old_parent))
+        {
+            auto& handles = children_pool->get(old_parent).handles;
+            std::erase(handles, child);
+            if (handles.empty()) children_pool->remove(old_parent);
+        }
+
+        parent_pool->remove(child);
+    }
+
+    void entities::remove_children(entity parent)
+    {
+        auto children_pool = get_pool<components::children>();
+        if (!children_pool->contains(parent)) return;
+
+        std::vector<entity> handles = children_pool->get(parent).handles;
+
+        auto parent_pool = get_pool<components::parent>();
+        for (entity child : handles)
+            if (parent_pool->contains(child)) parent_pool->remove(child);
+
+        children_pool->remove(parent);
     }
 
 } // namespace gamecoe

--- a/src/gamecoe/entity/entities.cpp
+++ b/src/gamecoe/entity/entities.cpp
@@ -105,10 +105,7 @@ namespace gamecoe
         auto parent_pool = get_pool<components::parent>();
         auto children_pool = get_pool<components::children>();
 
-        bool has_old = parent_pool->contains(child);
-        entity old_parent = has_old ? parent_pool->get(child).handle : entity::invalid();
-
-        if (has_old && old_parent == parent) return;
+        if (parent_pool->contains(child) && parent_pool->get(child).handle == parent) return;
 
         entity ancestor = parent;
         std::size_t guard = 0;
@@ -120,18 +117,8 @@ namespace gamecoe
             ++guard;
         }
 
-        if (has_old)
-        {
-            if (children_pool->contains(old_parent))
-            {
-                auto& handles = children_pool->get(old_parent).handles;
-                std::erase(handles, child);
-                if (handles.empty()) children_pool->remove(old_parent);
-            }
-        }
-
-        if (has_old) parent_pool->get(child).handle = parent;
-        else parent_pool->add(child, components::parent{ parent });
+        remove_parent(child);
+        parent_pool->add(child, components::parent{ parent });
 
         if (children_pool->contains(parent)) children_pool->get(parent).handles.push_back(child);
         else children_pool->add(parent, components::children{ { child } });
@@ -147,9 +134,8 @@ namespace gamecoe
         auto children_pool = get_pool<components::children>();
         if (children_pool->contains(old_parent))
         {
-            auto& handles = children_pool->get(old_parent).handles;
-            std::erase(handles, child);
-            if (handles.empty()) children_pool->remove(old_parent);
+            std::erase(children_pool->get(old_parent).handles, child);
+            if (!children_pool->get(old_parent).has_children()) children_pool->remove(old_parent);
         }
 
         parent_pool->remove(child);

--- a/src/gamecoe/entity/entities.cpp
+++ b/src/gamecoe/entity/entities.cpp
@@ -54,20 +54,27 @@ namespace gamecoe
     {
         if (!valid(e)) return;
 
-        remove_parent(e);
+        std::vector<entity> to_destroy{ e };
+        while (!to_destroy.empty())
+        {
+            entity current = to_destroy.back();
+            to_destroy.pop_back();
 
-        auto children_pool = get_pool<components::children>();
-        std::vector<entity> children_to_destroy;
-        if (children_pool->contains(e))
-            children_to_destroy = children_pool->get(e).handles;
+            if (!valid(current)) continue;
 
-        m_generations[e.id()]++;
-        m_recycle_ids.push_back(e.id());
+            remove_parent(current);
 
-        for (entity child : children_to_destroy)
-            if (valid(child)) destroy(child);
+            if (has_component<components::children>(current))
+            {
+                const auto& handles = get_pool<components::children>()->get(current).handles;
+                to_destroy.insert(to_destroy.end(), handles.begin(), handles.end());
+            }
 
-        for (auto &pool : m_pools) if (pool) pool->remove(e);
+            m_generations[current.id()]++;
+            m_recycle_ids.push_back(current.id());
+
+            for (auto &pool : m_pools) if (pool) pool->remove(current);
+        }
     }
 
     void entities::clear()
@@ -112,6 +119,8 @@ namespace gamecoe
         while (guard < size())
         {
             assert(ancestor != child && "entities::set_parent(): would create a parent/child cycle");
+            // Only relevant in release mode - we should have already caught cycles via the assert above in debug builds
+            if (ancestor == child) return;
             if (!parent_pool->contains(ancestor)) break;
             ancestor = parent_pool->get(ancestor).handle;
             ++guard;
@@ -126,14 +135,14 @@ namespace gamecoe
 
     void entities::remove_parent(entity child)
     {
-        auto parent_pool = get_pool<components::parent>();
-        if (!parent_pool->contains(child)) return;
+        if (!has_component<components::parent>(child)) return;
 
+        auto parent_pool = get_pool<components::parent>();
         entity old_parent = parent_pool->get(child).handle;
 
-        auto children_pool = get_pool<components::children>();
-        if (children_pool->contains(old_parent))
+        if (has_component<components::children>(old_parent))
         {
+            auto children_pool = get_pool<components::children>();
             std::erase(children_pool->get(old_parent).handles, child);
             if (!children_pool->get(old_parent).has_children()) children_pool->remove(old_parent);
         }
@@ -143,14 +152,13 @@ namespace gamecoe
 
     void entities::remove_children(entity parent)
     {
+        if (!has_component<components::children>(parent)) return;
+
         auto children_pool = get_pool<components::children>();
-        if (!children_pool->contains(parent)) return;
+        const auto& handles = children_pool->get(parent).handles;
 
-        std::vector<entity> handles = children_pool->get(parent).handles;
-
-        auto parent_pool = get_pool<components::parent>();
         for (entity child : handles)
-            if (parent_pool->contains(child)) parent_pool->remove(child);
+            if (has_component<components::parent>(child)) get_pool<components::parent>()->remove(child);
 
         children_pool->remove(parent);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(gamecoe_tests
     entity/extraction_tests.cpp
     component/transform_tests.cpp
     component/parent_child_tests.cpp
+    component/scene_tag_tests.cpp
     component/shape_renderer_tests.cpp
     component/shape_collider_tests.cpp
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(gamecoe_tests
     entity/component_pool_tests.cpp
     entity/entities_tests.cpp
     entity/extraction_tests.cpp
+    entity/command_buffer_tests.cpp
     component/transform_tests.cpp
     component/parent_child_tests.cpp
     component/scene_tag_tests.cpp

--- a/tests/component/scene_tag_tests.cpp
+++ b/tests/component/scene_tag_tests.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+#include <gamecoe/component/scene_tag.hpp>
+
+using namespace gamecoe;
+
+namespace gamecoe
+{
+    enum class scene_id : std::uint16_t
+    {
+        TestSceneA = 1,
+        TestSceneB = 2,
+    };
+} // namespace gamecoe
+
+//==============================================================================
+//                   SceneTagTests - scene_tag component tests
+//==============================================================================
+
+class SceneTagTests : public ::testing::Test
+{
+protected:
+    components::scene_tag tag;
+};
+
+//==============================================================================
+//                        Default State
+//==============================================================================
+
+TEST_F(SceneTagTests, DefaultState)
+{
+    // Test 1: Default-constructed scene_tag holds default-constructed scene_id
+    {
+        EXPECT_EQ(tag.id, scene_id{});
+        EXPECT_EQ(static_cast<std::uint16_t>(tag.id), 0);
+    }
+}
+
+//==============================================================================
+//                      Assigning Scene IDs
+//==============================================================================
+
+TEST_F(SceneTagTests, AssignSceneId)
+{
+    // Test 1: Assigning TestSceneA and verifying the value
+    {
+        tag.id = scene_id::TestSceneA;
+        EXPECT_EQ(tag.id, scene_id::TestSceneA);
+        EXPECT_EQ(static_cast<std::uint16_t>(tag.id), 1);
+    }
+
+    // Test 2: Reassigning to TestSceneB and verifying the new value
+    {
+        tag.id = scene_id::TestSceneB;
+        EXPECT_EQ(tag.id, scene_id::TestSceneB);
+        EXPECT_EQ(static_cast<std::uint16_t>(tag.id), 2);
+    }
+}
+
+//==============================================================================
+//                   Raw Value Construction
+//==============================================================================
+
+TEST_F(SceneTagTests, RawValueConstruction)
+{
+    // Test 1: Constructing scene_tag with a raw scene_id value (no enumerator)
+    {
+        components::scene_tag other{scene_id{42}};
+        EXPECT_EQ(other.id, scene_id{42});
+        EXPECT_EQ(static_cast<std::uint16_t>(other.id), 42);
+    }
+}

--- a/tests/component/transform_tests.cpp
+++ b/tests/component/transform_tests.cpp
@@ -1,44 +1,9 @@
 #include <gtest/gtest.h>
 #include <gamecoe/component/transform.hpp>
-#include <glm/gtc/epsilon.hpp>
+#include "../test_utils.hpp"
 
 using namespace gamecoe;
-
-namespace
-{
-    void expect_vec3_near(const glm::vec3 &actual, const glm::vec3 &expected, float epsilon = 1e-5f)
-    {
-        EXPECT_NEAR(actual.x, expected.x, epsilon);
-        EXPECT_NEAR(actual.y, expected.y, epsilon);
-        EXPECT_NEAR(actual.z, expected.z, epsilon);
-    }
-
-    void expect_quat_near(const glm::quat &actual, const glm::quat &expected, float epsilon = 1e-5f)
-    {
-        EXPECT_NEAR(actual.w, expected.w, epsilon);
-        EXPECT_NEAR(actual.x, expected.x, epsilon);
-        EXPECT_NEAR(actual.y, expected.y, epsilon);
-        EXPECT_NEAR(actual.z, expected.z, epsilon);
-    }
-
-    void expect_mat4_near(const glm::mat4 &actual, const glm::mat4 &expected, float epsilon = 1e-5f)
-    {
-        for (int col = 0; col < 4; ++col)
-            for (int row = 0; row < 4; ++row)
-                EXPECT_NEAR(actual[col][row], expected[col][row], epsilon);
-    }
-
-    // Boolean-only comparison used to assert two quaternions are NOT approximately
-    // equal (used to prove the two composition-order candidates in the
-    // rotate()/rotate_around() regression test actually differ). No per-component
-    // diagnostics needed here, unlike expect_quat_near(), since the check is just
-    // "these must not be equal" - matches the existing glm::epsilonEqual pattern
-    // used for the same purpose in src/gamecoe/utils/collision.cpp.old.
-    bool quat_near(const glm::quat &a, const glm::quat &b, float epsilon = 1e-4f)
-    {
-        return glm::all(glm::epsilonEqual(a, b, epsilon));
-    }
-} // namespace
+using namespace test_utils;
 
 //==============================================================================
 //                 TransformTests - transform component tests

--- a/tests/entity/command_buffer_tests.cpp
+++ b/tests/entity/command_buffer_tests.cpp
@@ -3,26 +3,10 @@
 #include <gamecoe/entity/entities.hpp>
 #include <gamecoe/component/transform.hpp>
 #include <gamecoe/component/scene_tag.hpp>
+#include "../test_utils.hpp"
 
 using namespace gamecoe;
-
-namespace
-{
-    void expect_vec3_near(const glm::vec3 &actual, const glm::vec3 &expected, float epsilon = 1e-5f)
-    {
-        EXPECT_NEAR(actual.x, expected.x, epsilon);
-        EXPECT_NEAR(actual.y, expected.y, epsilon);
-        EXPECT_NEAR(actual.z, expected.z, epsilon);
-    }
-
-    void expect_quat_near(const glm::quat &actual, const glm::quat &expected, float epsilon = 1e-5f)
-    {
-        EXPECT_NEAR(actual.w, expected.w, epsilon);
-        EXPECT_NEAR(actual.x, expected.x, epsilon);
-        EXPECT_NEAR(actual.y, expected.y, epsilon);
-        EXPECT_NEAR(actual.z, expected.z, epsilon);
-    }
-} // namespace
+using namespace test_utils;
 
 //==============================================================================
 //                    Test Component Types

--- a/tests/entity/command_buffer_tests.cpp
+++ b/tests/entity/command_buffer_tests.cpp
@@ -1,0 +1,169 @@
+#include <gtest/gtest.h>
+#include <gamecoe/entity/command_buffer.hpp>
+#include <gamecoe/entity/entities.hpp>
+#include <gamecoe/component/transform.hpp>
+#include <gamecoe/component/scene_tag.hpp>
+
+using namespace gamecoe;
+
+namespace
+{
+    void expect_vec3_near(const glm::vec3 &actual, const glm::vec3 &expected, float epsilon = 1e-5f)
+    {
+        EXPECT_NEAR(actual.x, expected.x, epsilon);
+        EXPECT_NEAR(actual.y, expected.y, epsilon);
+        EXPECT_NEAR(actual.z, expected.z, epsilon);
+    }
+
+    void expect_quat_near(const glm::quat &actual, const glm::quat &expected, float epsilon = 1e-5f)
+    {
+        EXPECT_NEAR(actual.w, expected.w, epsilon);
+        EXPECT_NEAR(actual.x, expected.x, epsilon);
+        EXPECT_NEAR(actual.y, expected.y, epsilon);
+        EXPECT_NEAR(actual.z, expected.z, epsilon);
+    }
+} // namespace
+
+//==============================================================================
+//                    Test Component Types
+//==============================================================================
+
+struct Tag
+{
+    int value;
+};
+
+//==============================================================================
+//                    CommandBufferTests - Command buffer tests
+//==============================================================================
+
+class CommandBufferTests : public ::testing::Test
+{
+protected:
+    entities mgr;
+    command_buffer buf;
+};
+
+//==============================================================================
+//                        Spawn And Flush
+//==============================================================================
+
+TEST_F(CommandBufferTests, SpawnAndFlush)
+{
+    // Test 1: nothing exists until flush
+    {
+        buf.spawn();
+        EXPECT_EQ(mgr.size(), 0);
+        buf.clear();
+    }
+
+    // Test 2: spawn with explicit transform flushes to an entity with that transform
+    {
+        components::transform t;
+        t.position = glm::vec3(1.0f, 2.0f, 3.0f);
+        t.rotation = glm::angleAxis(0.5f, glm::vec3(0.0f, 1.0f, 0.0f));
+        t.scale = glm::vec3(2.0f, 2.0f, 2.0f);
+
+        buf.spawn(t);
+        buf.flush(mgr);
+
+        ASSERT_EQ(mgr.size(), 1);
+        entity e = entity::invalid();
+        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
+        {
+            e = ent;
+        });
+
+        expect_vec3_near(mgr.transform(e).position, t.position);
+        expect_quat_near(mgr.transform(e).rotation, t.rotation);
+        expect_vec3_near(mgr.transform(e).scale, t.scale);
+    }
+
+    // Test 3: spawn with no args flushes to a default-constructed transform
+    {
+        mgr.clear();
+        buf.spawn();
+        buf.flush(mgr);
+
+        ASSERT_EQ(mgr.size(), 1);
+        entity e = entity::invalid();
+        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
+        {
+            e = ent;
+        });
+
+        expect_vec3_near(mgr.transform(e).position, glm::vec3(0.0f));
+        expect_quat_near(mgr.transform(e).rotation, glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
+        expect_vec3_near(mgr.transform(e).scale, glm::vec3(1.0f));
+    }
+
+    // Test 4: plain add<T> roundtrips a local test component onto the flushed entity
+    {
+        mgr.clear();
+        command_buffer::placeholder p = buf.spawn();
+        buf.add<Tag>(p, Tag{42});
+        buf.flush(mgr);
+
+        ASSERT_EQ(mgr.size(), 1);
+        entity e = entity::invalid();
+        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
+        {
+            e = ent;
+        });
+
+        ASSERT_TRUE(mgr.has_component<Tag>(e));
+        EXPECT_EQ(mgr.get_component<Tag>(e)->value, 42);
+    }
+
+    // Test 5: buffer is empty after flush; a second flush creates nothing new
+    {
+        mgr.clear();
+        buf.spawn();
+        buf.flush(mgr);
+
+        EXPECT_TRUE(buf.empty());
+        EXPECT_EQ(mgr.size(), 1);
+
+        buf.flush(mgr);
+        EXPECT_EQ(mgr.size(), 1);
+    }
+}
+
+//==============================================================================
+//                        Scene Tagging
+//==============================================================================
+
+TEST_F(CommandBufferTests, SceneTagging)
+{
+    // Test 1: flush with a scene stamps scene_tag on the created entity
+    {
+        buf.spawn();
+        buf.flush(mgr, scene_id{1});
+
+        ASSERT_EQ(mgr.size(), 1);
+        entity e = entity::invalid();
+        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
+        {
+            e = ent;
+        });
+
+        ASSERT_TRUE(mgr.has_component<components::scene_tag>(e));
+        EXPECT_EQ(mgr.get_component<components::scene_tag>(e)->id, scene_id{1});
+    }
+
+    // Test 2: flush with no scene leaves the entity untagged - default is global
+    {
+        mgr.clear();
+        buf.spawn();
+        buf.flush(mgr);
+
+        ASSERT_EQ(mgr.size(), 1);
+        entity e = entity::invalid();
+        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
+        {
+            e = ent;
+        });
+
+        EXPECT_FALSE(mgr.has_component<components::scene_tag>(e));
+    }
+}

--- a/tests/entity/command_buffer_tests.cpp
+++ b/tests/entity/command_buffer_tests.cpp
@@ -3,6 +3,7 @@
 #include <gamecoe/entity/entities.hpp>
 #include <gamecoe/component/transform.hpp>
 #include <gamecoe/component/scene_tag.hpp>
+#include <gamecoe/component/parent_child.hpp>
 #include "../test_utils.hpp"
 
 using namespace gamecoe;
@@ -194,5 +195,92 @@ TEST_F(CommandBufferTests, CallableResolution)
         EXPECT_NE(mgr.get_component<follow_target>(entity_a)->target, entity::invalid());
         
         // buf.add<components::parent>(p_a, components::parent{}); // compile error: hierarchy components are managed
+    }
+}
+
+//==============================================================================
+//                        Buffered Set Parent
+//==============================================================================
+
+TEST_F(CommandBufferTests, BufferedSetParent)
+{
+    // Test 1: buffered set_parent applies bidirectionally at flush via entities::set_parent()
+    {
+        mgr.clear();
+        command_buffer::placeholder p_child = buf.spawn();
+        command_buffer::placeholder p_parent = buf.spawn();
+        buf.add<Tag>(p_child, Tag{1});
+        buf.add<Tag>(p_parent, Tag{2});
+        buf.set_parent(p_child, p_parent);
+        buf.flush(mgr);
+
+        ASSERT_EQ(mgr.size(), 2);
+
+        entity real_child = entity::invalid();
+        entity real_parent = entity::invalid();
+        mgr.for_each<Tag>([&real_child, &real_parent](entity ent, const Tag &tag)
+        {
+            if (tag.value == 1) real_child = ent;
+            else if (tag.value == 2) real_parent = ent;
+        });
+
+        ASSERT_NE(real_child, entity::invalid());
+        ASSERT_NE(real_parent, entity::invalid());
+
+        ASSERT_TRUE(mgr.has_component<components::parent>(real_child));
+        EXPECT_EQ(mgr.get_component<components::parent>(real_child)->handle, real_parent);
+
+        ASSERT_TRUE(mgr.has_component<components::children>(real_parent));
+        const std::vector<entity> &handles = mgr.get_component<components::children>(real_parent)->handles;
+        ASSERT_EQ(handles.size(), 1);
+        EXPECT_EQ(handles[0], real_child);
+    }
+
+    // Test 2: multiple set_parent calls on the same parent accumulate in buffered order, interleaved with an unrelated add()
+    {
+        mgr.clear();
+        command_buffer::placeholder p_parent = buf.spawn();
+        command_buffer::placeholder p_child1 = buf.spawn();
+        command_buffer::placeholder p_child2 = buf.spawn();
+        command_buffer::placeholder p_child3 = buf.spawn();
+        command_buffer::placeholder p_other = buf.spawn();
+
+        buf.add<Tag>(p_parent, Tag{0});
+        buf.add<Tag>(p_child1, Tag{1});
+        buf.add<Tag>(p_child2, Tag{2});
+        buf.add<Tag>(p_child3, Tag{3});
+
+        buf.set_parent(p_child1, p_parent);
+        buf.add<Tag>(p_other, Tag{99});
+        buf.set_parent(p_child2, p_parent);
+        buf.set_parent(p_child3, p_parent);
+
+        buf.flush(mgr);
+
+        ASSERT_EQ(mgr.size(), 5);
+
+        entity real_parent = entity::invalid();
+        entity real_child1 = entity::invalid();
+        entity real_child2 = entity::invalid();
+        entity real_child3 = entity::invalid();
+        mgr.for_each<Tag>([&real_parent, &real_child1, &real_child2, &real_child3](entity ent, const Tag &tag)
+        {
+            if (tag.value == 0) real_parent = ent;
+            else if (tag.value == 1) real_child1 = ent;
+            else if (tag.value == 2) real_child2 = ent;
+            else if (tag.value == 3) real_child3 = ent;
+        });
+
+        ASSERT_NE(real_parent, entity::invalid());
+        ASSERT_NE(real_child1, entity::invalid());
+        ASSERT_NE(real_child2, entity::invalid());
+        ASSERT_NE(real_child3, entity::invalid());
+
+        ASSERT_TRUE(mgr.has_component<components::children>(real_parent));
+        const std::vector<entity> &handles = mgr.get_component<components::children>(real_parent)->handles;
+        ASSERT_EQ(handles.size(), 3);
+        EXPECT_EQ(handles[0], real_child1);
+        EXPECT_EQ(handles[1], real_child2);
+        EXPECT_EQ(handles[2], real_child3);
     }
 }

--- a/tests/entity/command_buffer_tests.cpp
+++ b/tests/entity/command_buffer_tests.cpp
@@ -57,8 +57,8 @@ TEST_F(CommandBufferTests, SpawnAndFlush)
         buf.spawn(t);
         buf.flush(mgr);
 
-        ASSERT_EQ(mgr.size(), 1);
-        entity e = sole_entity(mgr);
+        entity e = entity::invalid();
+        ASSERT_NO_FATAL_FAILURE(sole_entity(mgr, e));
 
         expect_vec3_near(mgr.transform(e).position, t.position);
         expect_quat_near(mgr.transform(e).rotation, t.rotation);
@@ -71,8 +71,8 @@ TEST_F(CommandBufferTests, SpawnAndFlush)
         buf.spawn();
         buf.flush(mgr);
 
-        ASSERT_EQ(mgr.size(), 1);
-        entity e = sole_entity(mgr);
+        entity e = entity::invalid();
+        ASSERT_NO_FATAL_FAILURE(sole_entity(mgr, e));
 
         expect_vec3_near(mgr.transform(e).position, glm::vec3(0.0f));
         expect_quat_near(mgr.transform(e).rotation, glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
@@ -86,8 +86,8 @@ TEST_F(CommandBufferTests, SpawnAndFlush)
         buf.add<Tag>(p, Tag{42});
         buf.flush(mgr);
 
-        ASSERT_EQ(mgr.size(), 1);
-        entity e = sole_entity(mgr);
+        entity e = entity::invalid();
+        ASSERT_NO_FATAL_FAILURE(sole_entity(mgr, e));
 
         ASSERT_TRUE(mgr.has_component<Tag>(e));
         EXPECT_EQ(mgr.get_component<Tag>(e)->value, 42);
@@ -118,8 +118,8 @@ TEST_F(CommandBufferTests, SceneTagging)
         buf.spawn();
         buf.flush(mgr, scene_id{1});
 
-        ASSERT_EQ(mgr.size(), 1);
-        entity e = sole_entity(mgr);
+        entity e = entity::invalid();
+        ASSERT_NO_FATAL_FAILURE(sole_entity(mgr, e));
 
         ASSERT_TRUE(mgr.has_component<components::scene_tag>(e));
         EXPECT_EQ(mgr.get_component<components::scene_tag>(e)->id, scene_id{1});
@@ -131,8 +131,8 @@ TEST_F(CommandBufferTests, SceneTagging)
         buf.spawn();
         buf.flush(mgr);
 
-        ASSERT_EQ(mgr.size(), 1);
-        entity e = sole_entity(mgr);
+        entity e = entity::invalid();
+        ASSERT_NO_FATAL_FAILURE(sole_entity(mgr, e));
 
         EXPECT_FALSE(mgr.has_component<components::scene_tag>(e));
     }

--- a/tests/entity/command_buffer_tests.cpp
+++ b/tests/entity/command_buffer_tests.cpp
@@ -58,11 +58,7 @@ TEST_F(CommandBufferTests, SpawnAndFlush)
         buf.flush(mgr);
 
         ASSERT_EQ(mgr.size(), 1);
-        entity e = entity::invalid();
-        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
-        {
-            e = ent;
-        });
+        entity e = sole_entity(mgr);
 
         expect_vec3_near(mgr.transform(e).position, t.position);
         expect_quat_near(mgr.transform(e).rotation, t.rotation);
@@ -76,11 +72,7 @@ TEST_F(CommandBufferTests, SpawnAndFlush)
         buf.flush(mgr);
 
         ASSERT_EQ(mgr.size(), 1);
-        entity e = entity::invalid();
-        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
-        {
-            e = ent;
-        });
+        entity e = sole_entity(mgr);
 
         expect_vec3_near(mgr.transform(e).position, glm::vec3(0.0f));
         expect_quat_near(mgr.transform(e).rotation, glm::quat(1.0f, 0.0f, 0.0f, 0.0f));
@@ -95,11 +87,7 @@ TEST_F(CommandBufferTests, SpawnAndFlush)
         buf.flush(mgr);
 
         ASSERT_EQ(mgr.size(), 1);
-        entity e = entity::invalid();
-        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
-        {
-            e = ent;
-        });
+        entity e = sole_entity(mgr);
 
         ASSERT_TRUE(mgr.has_component<Tag>(e));
         EXPECT_EQ(mgr.get_component<Tag>(e)->value, 42);
@@ -131,11 +119,7 @@ TEST_F(CommandBufferTests, SceneTagging)
         buf.flush(mgr, scene_id{1});
 
         ASSERT_EQ(mgr.size(), 1);
-        entity e = entity::invalid();
-        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
-        {
-            e = ent;
-        });
+        entity e = sole_entity(mgr);
 
         ASSERT_TRUE(mgr.has_component<components::scene_tag>(e));
         EXPECT_EQ(mgr.get_component<components::scene_tag>(e)->id, scene_id{1});
@@ -148,11 +132,7 @@ TEST_F(CommandBufferTests, SceneTagging)
         buf.flush(mgr);
 
         ASSERT_EQ(mgr.size(), 1);
-        entity e = entity::invalid();
-        mgr.for_each<components::transform>([&e]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
-        {
-            e = ent;
-        });
+        entity e = sole_entity(mgr);
 
         EXPECT_FALSE(mgr.has_component<components::scene_tag>(e));
     }

--- a/tests/entity/command_buffer_tests.cpp
+++ b/tests/entity/command_buffer_tests.cpp
@@ -17,6 +17,11 @@ struct Tag
     int value;
 };
 
+struct follow_target
+{
+    entity target;
+};
+
 //==============================================================================
 //                    CommandBufferTests - Command buffer tests
 //==============================================================================
@@ -149,5 +154,45 @@ TEST_F(CommandBufferTests, SceneTagging)
         });
 
         EXPECT_FALSE(mgr.has_component<components::scene_tag>(e));
+    }
+}
+
+//==============================================================================
+//                        Callable Resolution
+//==============================================================================
+
+TEST_F(CommandBufferTests, CallableResolution)
+{
+    // Test 1: callable add<T> resolves a placeholder to a real entity reference
+    {
+        mgr.clear();
+        command_buffer::placeholder p_a = buf.spawn();
+        command_buffer::placeholder p_b = buf.spawn();
+        buf.add(p_a, [=](const command_buffer::resolver& r) { return follow_target{r.resolve(p_b)}; });
+        buf.flush(mgr);
+
+        ASSERT_EQ(mgr.size(), 2);
+        std::vector<entity> entities_list;
+        mgr.for_each<components::transform>([&entities_list]([[maybe_unused]] entity ent, [[maybe_unused]] const components::transform &tr)
+        {
+            entities_list.push_back(ent);
+        });
+
+        // Identify entity_a (has follow_target) and entity_b (doesn't)
+        entity entity_a = entity::invalid();
+        entity entity_b = entity::invalid();
+        for (entity e : entities_list)
+        {
+            if (mgr.has_component<follow_target>(e))
+                entity_a = e;
+            else
+                entity_b = e;
+        }
+
+        ASSERT_TRUE(mgr.has_component<follow_target>(entity_a));
+        EXPECT_EQ(mgr.get_component<follow_target>(entity_a)->target, entity_b);
+        EXPECT_NE(mgr.get_component<follow_target>(entity_a)->target, entity::invalid());
+        
+        // buf.add<components::parent>(p_a, components::parent{}); // compile error: hierarchy components are managed
     }
 }

--- a/tests/entity/entities_tests.cpp
+++ b/tests/entity/entities_tests.cpp
@@ -3,18 +3,10 @@
 #include <gamecoe/component/transform.hpp>
 #include <gamecoe/component/parent_child.hpp>
 #include <chrono>
+#include "../test_utils.hpp"
 
 using namespace gamecoe;
-
-namespace
-{
-    void expect_vec3_near(const glm::vec3 &actual, const glm::vec3 &expected, float epsilon = 1e-5f)
-    {
-        EXPECT_NEAR(actual.x, expected.x, epsilon);
-        EXPECT_NEAR(actual.y, expected.y, epsilon);
-        EXPECT_NEAR(actual.z, expected.z, epsilon);
-    }
-} // namespace
+using namespace test_utils;
 
 //==============================================================================
 //                    Test Component Types

--- a/tests/entity/entities_tests.cpp
+++ b/tests/entity/entities_tests.cpp
@@ -1,8 +1,19 @@
 #include <gtest/gtest.h>
 #include <gamecoe/entity/entities.hpp>
+#include <gamecoe/component/transform.hpp>
 #include <chrono>
 
 using namespace gamecoe;
+
+namespace
+{
+    void expect_vec3_near(const glm::vec3 &actual, const glm::vec3 &expected, float epsilon = 1e-5f)
+    {
+        EXPECT_NEAR(actual.x, expected.x, epsilon);
+        EXPECT_NEAR(actual.y, expected.y, epsilon);
+        EXPECT_NEAR(actual.z, expected.z, epsilon);
+    }
+} // namespace
 
 //==============================================================================
 //                    Test Component Types
@@ -276,4 +287,51 @@ TEST_F(EntitiesTests, Reserve)
     entity e = mgr.create();
     EXPECT_TRUE(mgr.valid(e));
     EXPECT_EQ(mgr.size(), 1);
+}
+
+//==============================================================================
+//                        Mandatory Transform
+//==============================================================================
+
+TEST_F(EntitiesTests, MandatoryTransform)
+{
+    // Test 1: Every entity has a transform immediately after create(), with default values
+    {
+        entity e = mgr.create();
+        EXPECT_TRUE(mgr.has_component<components::transform>(e));
+
+        components::transform *t = mgr.get_component<components::transform>(e);
+        ASSERT_NE(t, nullptr);
+        expect_vec3_near(t->position, glm::vec3(0.0f));
+        expect_vec3_near(t->scale, glm::vec3(1.0f));
+    }
+
+    // Test 2: transform is still present after removing other components (unaffected by unrelated removes)
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        mgr.add_component<Position>(e, Position{1.0f, 2.0f, 3.0f});
+        mgr.remove_component<Position>(e);
+
+        EXPECT_TRUE(mgr.has_component<components::transform>(e));
+    }
+
+    // Test 3: transform cannot be added or removed via the public API (compile-time guard)
+    // Uncommenting either line below must fail to compile:
+    // mgr.add_component<components::transform>(e);
+    // mgr.remove_component<components::transform>(e);
+
+    // Test 4: transform() accessor returns the same component as get_component<transform>(), no null-check needed
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        components::transform &t = mgr.transform(e);
+        t.position = glm::vec3(5.0f, 0.0f, 0.0f);
+
+        expect_vec3_near(mgr.get_component<components::transform>(e)->position, mgr.transform(e).position);
+
+        const entities &const_mgr = mgr;
+        const components::transform &const_t = const_mgr.transform(e);
+        expect_vec3_near(const_t.position, glm::vec3(5.0f, 0.0f, 0.0f));
+    }
 }

--- a/tests/entity/entities_tests.cpp
+++ b/tests/entity/entities_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <gamecoe/entity/entities.hpp>
 #include <gamecoe/component/transform.hpp>
+#include <gamecoe/component/parent_child.hpp>
 #include <chrono>
 
 using namespace gamecoe;
@@ -333,5 +334,260 @@ TEST_F(EntitiesTests, MandatoryTransform)
         const entities &const_mgr = mgr;
         const components::transform &const_t = const_mgr.transform(e);
         expect_vec3_near(const_t.position, glm::vec3(5.0f, 0.0f, 0.0f));
+    }
+}
+
+//==============================================================================
+//                        Hierarchy (set_parent / remove_parent / remove_children)
+//==============================================================================
+
+TEST_F(EntitiesTests, Hierarchy)
+{
+    // Test 1: set_parent makes both sides consistent
+    {
+        entity parent = mgr.create();
+        entity child = mgr.create();
+
+        mgr.set_parent(child, parent);
+
+        ASSERT_TRUE(mgr.has_component<components::parent>(child));
+        EXPECT_EQ(mgr.get_component<components::parent>(child)->handle, parent);
+
+        ASSERT_TRUE(mgr.has_component<components::children>(parent));
+        const auto &handles = mgr.get_component<components::children>(parent)->handles;
+        ASSERT_EQ(handles.size(), 1);
+        EXPECT_EQ(handles[0], child);
+    }
+
+    // Test 2: multiple children accumulate under one parent, in order
+    {
+        mgr.clear();
+        entity parent = mgr.create();
+        entity child0 = mgr.create();
+        entity child1 = mgr.create();
+
+        mgr.set_parent(child0, parent);
+        mgr.set_parent(child1, parent);
+
+        const auto &handles = mgr.get_component<components::children>(parent)->handles;
+        ASSERT_EQ(handles.size(), 2);
+        EXPECT_EQ(handles[0], child0);
+        EXPECT_EQ(handles[1], child1);
+    }
+
+    // Test 3: re-parenting detaches from the old parent (component removed once empty) and attaches to the new one
+    {
+        mgr.clear();
+        entity old_parent = mgr.create();
+        entity new_parent = mgr.create();
+        entity child = mgr.create();
+
+        mgr.set_parent(child, old_parent);
+        mgr.set_parent(child, new_parent);
+
+        EXPECT_EQ(mgr.get_component<components::parent>(child)->handle, new_parent);
+        EXPECT_FALSE(mgr.has_component<components::children>(old_parent));
+
+        const auto &new_handles = mgr.get_component<components::children>(new_parent)->handles;
+        ASSERT_EQ(new_handles.size(), 1);
+        EXPECT_EQ(new_handles[0], child);
+    }
+
+    // Test 4: repeated same-parent call is a no-op (doesn't duplicate)
+    {
+        mgr.clear();
+        entity parent = mgr.create();
+        entity child = mgr.create();
+
+        mgr.set_parent(child, parent);
+        mgr.set_parent(child, parent);
+
+        const auto &handles = mgr.get_component<components::children>(parent)->handles;
+        EXPECT_EQ(handles.size(), 1);
+    }
+
+    // Test 5: remove_parent detaches both sides; parent's children component is removed once it has no children left
+    {
+        mgr.clear();
+        entity parent = mgr.create();
+        entity child = mgr.create();
+        mgr.set_parent(child, parent);
+
+        mgr.remove_parent(child);
+
+        EXPECT_FALSE(mgr.has_component<components::parent>(child));
+        EXPECT_FALSE(mgr.has_component<components::children>(parent));
+        EXPECT_TRUE(mgr.valid(child)); // child remains a valid, independent entity
+    }
+
+    // Test 6: remove_parent with multiple children only detaches the specified one; children component remains for the rest
+    {
+        mgr.clear();
+        entity parent = mgr.create();
+        entity child0 = mgr.create();
+        entity child1 = mgr.create();
+        mgr.set_parent(child0, parent);
+        mgr.set_parent(child1, parent);
+
+        mgr.remove_parent(child0);
+
+        EXPECT_FALSE(mgr.has_component<components::parent>(child0));
+        ASSERT_TRUE(mgr.has_component<components::children>(parent));
+        const auto &handles = mgr.get_component<components::children>(parent)->handles;
+        ASSERT_EQ(handles.size(), 1);
+        EXPECT_EQ(handles[0], child1);
+    }
+
+    // Test 7: remove_parent on an unparented entity is a silent no-op
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        mgr.remove_parent(e);
+        EXPECT_FALSE(mgr.has_component<components::parent>(e));
+    }
+
+    // Test 8: remove_children detaches every child (kept alive) and clears the parent's children component
+    {
+        mgr.clear();
+        entity parent = mgr.create();
+        entity child0 = mgr.create();
+        entity child1 = mgr.create();
+        mgr.set_parent(child0, parent);
+        mgr.set_parent(child1, parent);
+
+        mgr.remove_children(parent);
+
+        EXPECT_FALSE(mgr.has_component<components::children>(parent));
+        EXPECT_FALSE(mgr.has_component<components::parent>(child0));
+        EXPECT_FALSE(mgr.has_component<components::parent>(child1));
+        EXPECT_TRUE(mgr.valid(child0));
+        EXPECT_TRUE(mgr.valid(child1));
+    }
+
+    // Test 9: remove_children on a childless entity is a silent no-op
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        mgr.remove_children(e);
+        EXPECT_FALSE(mgr.has_component<components::children>(e));
+    }
+
+    // Test 10: hierarchy components cannot be added/removed via the public API (compile-time guard)
+    // Uncommenting any line below must fail to compile:
+    // mgr.add_component<components::parent>(entity{}, components::parent{});
+    // mgr.remove_component<components::parent>(entity{});
+    // mgr.add_component<components::children>(entity{}, components::children{});
+    // mgr.remove_component<components::children>(entity{});
+}
+
+//==============================================================================
+//                        SetParent Cycle Detection (debug-time assert)
+//==============================================================================
+
+TEST_F(EntitiesTests, SetParentCycleDetection)
+{
+    // Test 1: direct 2-node cycle - A is already parent of B, then set_parent(A, B) would make B a
+    // parent of its own ancestor A
+    EXPECT_DEATH(
+        {
+            entity a = mgr.create();
+            entity b = mgr.create();
+            mgr.set_parent(b, a); // b's parent = a
+            mgr.set_parent(a, b); // would create a -> b -> a cycle
+        },
+        "would create a parent/child cycle");
+
+    // Test 2: indirect 3-node cycle - A -> B -> C existing chain, then set_parent(A, C) closes the loop
+    EXPECT_DEATH(
+        {
+            entity a = mgr.create();
+            entity b = mgr.create();
+            entity c = mgr.create();
+            mgr.set_parent(b, a); // b's parent = a
+            mgr.set_parent(c, b); // c's parent = b
+            mgr.set_parent(a, c); // would create a -> c -> b -> a cycle
+        },
+        "would create a parent/child cycle");
+}
+
+//==============================================================================
+//                        Destroy Cascade (destroy() with hierarchy)
+//==============================================================================
+
+TEST_F(EntitiesTests, DestroyCascade)
+{
+    // Test 1: destroying a childless, unparented entity still works (regression baseline)
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        mgr.destroy(e);
+
+        EXPECT_FALSE(mgr.valid(e));
+        EXPECT_EQ(mgr.size(), 0);
+    }
+
+    // Test 2: destroying a parent with one child destroys the child too
+    {
+        mgr.clear();
+        entity parent = mgr.create();
+        entity child = mgr.create();
+        mgr.set_parent(child, parent);
+
+        mgr.destroy(parent);
+
+        EXPECT_FALSE(mgr.valid(parent));
+        EXPECT_FALSE(mgr.valid(child));
+    }
+
+    // Test 3: destroying a parent with multiple children destroys all of them
+    {
+        mgr.clear();
+        entity parent = mgr.create();
+        entity child0 = mgr.create();
+        entity child1 = mgr.create();
+        mgr.set_parent(child0, parent);
+        mgr.set_parent(child1, parent);
+
+        mgr.destroy(parent);
+
+        EXPECT_FALSE(mgr.valid(parent));
+        EXPECT_FALSE(mgr.valid(child0));
+        EXPECT_FALSE(mgr.valid(child1));
+    }
+
+    // Test 4: destroying a root cascades through a multi-level hierarchy (grandchildren too)
+    {
+        mgr.clear();
+        entity root = mgr.create();
+        entity child = mgr.create();
+        entity grandchild = mgr.create();
+        mgr.set_parent(child, root);
+        mgr.set_parent(grandchild, child);
+
+        mgr.destroy(root);
+
+        EXPECT_FALSE(mgr.valid(root));
+        EXPECT_FALSE(mgr.valid(child));
+        EXPECT_FALSE(mgr.valid(grandchild));
+    }
+
+    // Test 5: destroying a middle node detaches upward (parent stays valid, loses it from children)
+    // and cascades downward (its own child is destroyed too)
+    {
+        mgr.clear();
+        entity root = mgr.create();
+        entity middle = mgr.create();
+        entity leaf = mgr.create();
+        mgr.set_parent(middle, root);
+        mgr.set_parent(leaf, middle);
+
+        mgr.destroy(middle);
+
+        EXPECT_TRUE(mgr.valid(root));
+        EXPECT_FALSE(mgr.valid(middle));
+        EXPECT_FALSE(mgr.valid(leaf));
+
+        // root's children component should no longer exist - middle was root's only child
+        EXPECT_FALSE(mgr.has_component<components::children>(root));
     }
 }

--- a/tests/entity/entities_tests.cpp
+++ b/tests/entity/entities_tests.cpp
@@ -478,6 +478,10 @@ TEST_F(EntitiesTests, Hierarchy)
 
 TEST_F(EntitiesTests, SetParentCycleDetection)
 {
+#ifdef NDEBUG
+    GTEST_SKIP() << "cycle detection assert is compiled out under NDEBUG (Release build)";
+#endif
+
     // Test 1: direct 2-node cycle - A is already parent of B, then set_parent(A, B) would make B a
     // parent of its own ancestor A
     EXPECT_DEATH(

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -16,6 +16,7 @@ int printHelp()
     std::cout << "  SparseSetTests           - Sparse set data structure tests" << std::endl;
     std::cout << "  ComponentPoolTests       - Component pool wrapper tests" << std::endl;
     std::cout << "  EntitiesTests            - Entities manager tests" << std::endl;
+    std::cout << "  CommandBufferTests       - Command buffer tests" << std::endl;
     std::cout << "  TransformTests           - Transform component tests" << std::endl;
     std::cout << "  ParentTests              - Parent component tests" << std::endl;
     std::cout << "  ChildrenTests            - Children component tests" << std::endl;
@@ -36,7 +37,7 @@ int main(int argc, char **argv)
     std::cout << "====================================================" << std::endl;
     std::cout << std::endl;
     std::cout << "Comprehensive testing for gamecoe." << std::endl;
-    std::cout << "Testing Entity Module: entity, sparse_set, component_pool, entities" << std::endl;
+    std::cout << "Testing Entity Module: entity, sparse_set, component_pool, entities, command_buffer" << std::endl;
     std::cout << "Testing Component Module: transform, parent, children, scene_tag, shape_renderer, shape_collider" << std::endl;
     std::cout << std::endl;
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -19,6 +19,7 @@ int printHelp()
     std::cout << "  TransformTests           - Transform component tests" << std::endl;
     std::cout << "  ParentTests              - Parent component tests" << std::endl;
     std::cout << "  ChildrenTests            - Children component tests" << std::endl;
+    std::cout << "  SceneTagTests            - Scene tag component tests" << std::endl;
     std::cout << "  ShapeRendererTests       - Shape renderer component tests" << std::endl;
     std::cout << "  ShapeColliderTests       - Shape collider component tests" << std::endl;
     std::cout << std::endl;
@@ -36,7 +37,7 @@ int main(int argc, char **argv)
     std::cout << std::endl;
     std::cout << "Comprehensive testing for gamecoe." << std::endl;
     std::cout << "Testing Entity Module: entity, sparse_set, component_pool, entities" << std::endl;
-    std::cout << "Testing Component Module: transform, parent, children, shape_renderer, shape_collider" << std::endl;
+    std::cout << "Testing Component Module: transform, parent, children, scene_tag, shape_renderer, shape_collider" << std::endl;
     std::cout << std::endl;
 
     testcoe::init(&argc, argv);

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -8,16 +8,16 @@
 #include <gamecoe/component/transform.hpp>
 namespace test_utils
 {
-    // Returns the single entity in mgr (expects there's exactly one), for tests that flush one spawn and need its real handle
-    inline gamecoe::entity sole_entity(gamecoe::entities &mgr)
+    // Fatally asserts mgr has exactly one entity, then writes its handle to out (for tests that flush one spawn and need its real handle).
+    // Callers MUST wrap the call in ASSERT_NO_FATAL_FAILURE(...) - a fatal assert inside this helper only unwinds this function, not the caller's TEST_F.
+    inline void sole_entity(gamecoe::entities &mgr, gamecoe::entity &out)
     {
-        EXPECT_EQ(mgr.size(), 1u) << "test_utils::sole_entity(): expected exactly one entity in mgr";
-        gamecoe::entity e = gamecoe::entity::invalid();
-        mgr.for_each<gamecoe::components::transform>([&e](gamecoe::entity ent, [[maybe_unused]] const gamecoe::components::transform &tr)
+        ASSERT_EQ(mgr.size(), 1u) << "test_utils::sole_entity(): expected exactly one entity in mgr";
+        out = gamecoe::entity::invalid();
+        mgr.for_each<gamecoe::components::transform>([&out](gamecoe::entity ent, [[maybe_unused]] const gamecoe::components::transform &tr)
         {
-            e = ent;
+            out = ent;
         });
-        return e;
     }
 
     inline void expect_vec3_near(const glm::vec3 &actual, const glm::vec3 &expected, float epsilon = 1e-5f)

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+#include <glm/gtc/epsilon.hpp>
+#include <gtest/gtest.h>
+
+namespace test_utils
+{
+    inline void expect_vec3_near(const glm::vec3 &actual, const glm::vec3 &expected, float epsilon = 1e-5f)
+    {
+        EXPECT_NEAR(actual.x, expected.x, epsilon);
+        EXPECT_NEAR(actual.y, expected.y, epsilon);
+        EXPECT_NEAR(actual.z, expected.z, epsilon);
+    }
+
+    inline void expect_quat_near(const glm::quat &actual, const glm::quat &expected, float epsilon = 1e-5f)
+    {
+        EXPECT_NEAR(actual.w, expected.w, epsilon);
+        EXPECT_NEAR(actual.x, expected.x, epsilon);
+        EXPECT_NEAR(actual.y, expected.y, epsilon);
+        EXPECT_NEAR(actual.z, expected.z, epsilon);
+    }
+
+    inline void expect_mat4_near(const glm::mat4 &actual, const glm::mat4 &expected, float epsilon = 1e-5f)
+    {
+        for (int col = 0; col < 4; ++col)
+            for (int row = 0; row < 4; ++row)
+                EXPECT_NEAR(actual[col][row], expected[col][row], epsilon);
+    }
+
+    inline bool quat_near(const glm::quat &a, const glm::quat &b, float epsilon = 1e-4f)
+    {
+        return glm::all(glm::epsilonEqual(a, b, epsilon));
+    }
+} // namespace test_utils

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -4,9 +4,22 @@
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtc/epsilon.hpp>
 #include <gtest/gtest.h>
-
+#include <gamecoe/entity/entities.hpp>
+#include <gamecoe/component/transform.hpp>
 namespace test_utils
 {
+    // Returns the single entity in mgr (expects there's exactly one), for tests that flush one spawn and need its real handle
+    inline gamecoe::entity sole_entity(gamecoe::entities &mgr)
+    {
+        EXPECT_EQ(mgr.size(), 1u) << "test_utils::sole_entity(): expected exactly one entity in mgr";
+        gamecoe::entity e = gamecoe::entity::invalid();
+        mgr.for_each<gamecoe::components::transform>([&e](gamecoe::entity ent, [[maybe_unused]] const gamecoe::components::transform &tr)
+        {
+            e = ent;
+        });
+        return e;
+    }
+
     inline void expect_vec3_near(const glm::vec3 &actual, const glm::vec3 &expected, float epsilon = 1e-5f)
     {
         EXPECT_NEAR(actual.x, expected.x, epsilon);


### PR DESCRIPTION
Scenes need to load async on a different thread, which means building entities before any real IDs exist - including references between them, like a child pointing at a parent that hasn't been created yet. 
command_buffer solves that with placeholders resolved at flush() time. 
This also brings the entities API it leans on: a mandatory transform on every entity, live hierarchy management, and cascading destroy().

- Add mandatory transform on every entity via entities::create(), plus a transform() accessor
- Add entities::set_parent()/remove_parent()/remove_children() for bidirectional hierarchy management, with cycle detection
- Rework entities::destroy() to cascade all descendants
- Add static_assert guards blocking direct add_component/remove_component for transform/parent/children
- Fix component_pool::add() to overwrite on a duplicate-entity add in Release instead of discarding the value
- Add scene_id forward declaration and scene_tag POD component
- Add command_buffer: spawn(), add() (value and callable overloads), set_parent(), flush() for deferred scene population with placeholder resolution and optional scene tagging
- Extract duplicated GLM test helpers into tests/test_utils.hpp
- Add tests for hierarchy management, cascade destroy, cycle detection, scene_tag, and command_buffer