### PR TITLE
[Docs]: Backfill comments and logging

### DIFF
--- a/include/gamecoe/component/collision_callbacks.hpp
+++ b/include/gamecoe/component/collision_callbacks.hpp
@@ -9,6 +9,10 @@ namespace gamecoe
 
     namespace components
     {
+        // Takes two entities& even though the engine only has one shared registry today -
+        // kept dual-parameter shaped for forward-compatibility,
+        // both are the same reference passed twice at the call site under the current single-registry model.
+        // Revisit collapsing to a single entities& parameter if a second registry never materializes.
         using collision_callback = void(*)(entity self, entities& self_registry, entity other, entities& other_registry);
 
         struct collision_callbacks

--- a/include/gamecoe/component/transform.hpp
+++ b/include/gamecoe/component/transform.hpp
@@ -18,6 +18,8 @@ namespace gamecoe
             glm::mat4 translation_matrix() const { return glm::translate(glm::mat4(1.0f), position); }
             glm::mat4 rotation_matrix() const { return glm::mat4_cast(rotation); }
             glm::mat4 scale_matrix() const { return glm::scale(glm::mat4(1.0f), scale); }
+            // Built by hand instead of translation_matrix() * rotation_matrix() * scale_matrix()
+            // to avoid two extra mat4 multiplications - this runs per-entity, per-frame.
             glm::mat4 local_matrix() const
             {
                 glm::mat4 m = glm::mat4_cast(rotation);

--- a/include/gamecoe/core/scene_id.hpp
+++ b/include/gamecoe/core/scene_id.hpp
@@ -4,8 +4,7 @@
 
 namespace gamecoe
 {
-    // Opaque forward declaration
-    // fixed underlying type keeps this complete for storage, comparison, and pass-by-value with no enumerators needed.
+    // Fixed underlying type keeps this complete for storage, comparison, and pass-by-value with no enumerators needed.
     // gencoe generates the concrete enum body into the game project, extending namespace gamecoe.
     enum class scene_id : std::uint16_t;
 } // namespace gamecoe

--- a/include/gamecoe/entity/command_buffer.hpp
+++ b/include/gamecoe/entity/command_buffer.hpp
@@ -22,6 +22,8 @@ namespace gamecoe
         struct placeholder
         {
         private:
+            // Opaque token, not a real entity until flush() - same "safety over convenience"
+            // precedent as entity itself. Private ctor + friend keeps callers from forging one.
             std::uint32_t m_index;
             explicit constexpr placeholder(std::uint32_t index) noexcept : m_index(index) { }
             friend class command_buffer;
@@ -51,6 +53,8 @@ namespace gamecoe
                 "command_buffer::add(): hierarchy components are managed - use command_buffer::set_parent() instead");
 
             if constexpr (std::is_same_v<T, components::transform>)
+                // transform is assigned directly since add_component<transform>() is static_assert-blocked
+                // (transform is mandatory, always present, never added through this generic path).
                 ents.transform(e) = std::move(value);
             else
             {
@@ -63,7 +67,8 @@ namespace gamecoe
         // Queues an entity with the given transform (default if omitted). No real entity until flush().
         placeholder spawn(components::transform t = components::transform{});
 
-        // Queues a component add-or-assign, applied at flush().
+        // Queues a component add-or-assign, applied at flush(). Add-only would always fail for
+        // transform (every spawned entity already has one), so add-or-assign covers every component type the same way.
         template <typename T>
         requires (!std::invocable<T, const resolver&>)
         void add(placeholder p, T value)

--- a/include/gamecoe/entity/component_pool.hpp
+++ b/include/gamecoe/entity/component_pool.hpp
@@ -4,7 +4,7 @@
 #include <gamecoe/entity/entity.hpp>
 #include <gamecoe/entity/sparse_set.hpp>
 #include <vector>
-#include <cassert>
+#include <gamecoe/utils/error_handler.hpp>
 
 namespace gamecoe
 {
@@ -12,8 +12,10 @@ namespace gamecoe
     {
     protected:
         sparse_set m_entities;
-        
+
     private:
+        // Base always reserves the sparse_set, derived always reserves its dense array through this override,
+        // so neither one can be forgotten.
         virtual void do_reserve(std::size_t capacity) = 0;
 
     public:
@@ -73,8 +75,8 @@ namespace gamecoe
         {
             if (contains(e))
             {
-                assert(false && "component_pool::add(): entity already has this component");
-                // overwriting with the new value on release build mode
+                GAMECOE_ASSERT_LOG(false, "component_pool::add(): entity already has this component");
+                // Release has no assert, so we overwrite instead of silently discarding the caller's new value.
                 T &existing = m_components[m_entities.index(e).value()];
                 existing = T(std::forward<Args>(args)...);
                 return existing;
@@ -86,10 +88,12 @@ namespace gamecoe
             return m_components.back();
         }
 
+        // Asserts and returns T& (not nullable), callers here already checked contains().
+        // entities::get_component<T>() returns a nullable pointer instead since its callers don't always know.
         T& get(entity e)
         {
             auto index = m_entities.index(e);
-            assert(index && "component_pool::get(): entity does not exist in the pool");
+            GAMECOE_ASSERT_LOG(index, "component_pool::get(): entity does not exist in the pool");
 
             return m_components[index.value()];
         }
@@ -97,7 +101,7 @@ namespace gamecoe
         const T& get(entity e) const
         {
             auto index = m_entities.index(e);
-            assert(index && "component_pool::get(): entity does not exist in the pool");
+            GAMECOE_ASSERT_LOG(index, "component_pool::get(): entity does not exist in the pool");
 
             return m_components[index.value()];
         }

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <cstdint>
 #include <cassert>
+#include <gamecoe/utils/error_handler.hpp>
 
 namespace gamecoe
 {
@@ -26,6 +27,8 @@ namespace gamecoe
 
     class entities
     {
+        // Plain counters, not atomics. Atomics would imply a thread-safety guarantee
+        // this ECS doesn't have yet, revisit once the threading model is decided.
         static std::uint32_t s_component_id;
 
         std::vector<std::unique_ptr<basic_component_pool>> m_pools;
@@ -42,7 +45,7 @@ namespace gamecoe
             return s_componentT_id;
         }
 
-        // Returns a pointer to the realtime type component_pool<T> of the T component, creates a new pool if not exists
+        // Creates a new pool if not exists (lazy auto-registration).
         template <typename T>
         component_pool<T>* get_pool()
         {
@@ -63,25 +66,22 @@ namespace gamecoe
 
         ~entities() = default;
 
-        // Creates an entity (may be recycled id)
+        // May return a recycled id.
         entity create();
 
-        // Destroy an entity
+        // No-op if e is already invalid.
         void destroy(entity e);
 
-        // Destroys all entities
         void clear();
 
-        // Returns if the entity handle given is valid
         bool valid(entity e) const;
 
-        // Reserves capacity for a number of entities
+        // Also reserves capacity in every existing component pool, not just entity bookkeeping.
         void reserve(std::size_t capacity);
 
-        // Returns the number of alive entities
         std::size_t size() const;
 
-        // Emplaces a new T component to entity e
+        // Entity must already be valid, asserted.
         template <typename T, typename... Args>
         T& add_component(entity e, Args&&... args)
         {
@@ -90,13 +90,13 @@ namespace gamecoe
             static_assert(!hierarchy_component<T>,
                 "entities::add_component(): hierarchy components are managed - use entities::set_parent() instead");
 
-            assert(valid(e) && "entities::add_component(): entity is not valid");
+            GAMECOE_ASSERT_LOG(valid(e), "entities::add_component(): entity is not valid");
 
             auto pool = get_pool<T>();
             return pool->add(e, std::forward<Args>(args)...);
         }
 
-        // Returns if entity e has a component T
+        // Safe on an invalid entity, returns false rather than asserting.
         template <typename T>
         bool has_component(entity e) const
         {
@@ -108,7 +108,7 @@ namespace gamecoe
             return m_pools[comp_id]->contains(e);
         }
 
-        // Removes component T from entity e
+        // No-op if e doesn't have T, or e is invalid.
         template <typename T>
         void remove_component(entity e)
         {
@@ -122,8 +122,7 @@ namespace gamecoe
             m_pools[component_id<T>()]->remove(e);
         }
 
-        // Returns a pointer to component T of entity e (`nullptr` if entity doesn't have T component),
-        // also note that the pointer may invalidated by any `add_component` call
+        // Pointer may be invalidated by any add_component call (pool reallocation).
         template <typename T>
         T* get_component(entity e)
         {
@@ -133,8 +132,7 @@ namespace gamecoe
             return &(pool->get(e));
         }
 
-        // Returns a pointer to component T of entity e (`nullptr` if entity doesn't have T component),
-        // also note that the pointer may invalidated by any `add_component` call
+        // Pointer may be invalidated by any add_component call (pool reallocation).
         template <typename T>
         const T* get_component(entity e) const
         {
@@ -144,22 +142,21 @@ namespace gamecoe
             return &(pool->get(e));
         }
 
-        // Direct accessor for the mandatory transform component
+        // Transform always exists.
         components::transform& transform(entity e);
 
-        // Direct accessor for the mandatory transform component
+        // Transform always exists.
         const components::transform& transform(entity e) const;
 
-        // Sets child's parent, updating both sides.
+        // Updates both sides.
         void set_parent(entity child, entity parent);
 
-        // Removes child's parent link, updating both sides.
+        // Updates both sides.
         void remove_parent(entity child);
 
-        // Removes all of the entity's children, updating both sides.
+        // Updates both sides.
         void remove_children(entity parent);
 
-        // Iterates over all entities and their components and run func() on each of them
         template <typename T, typename Func>
         void for_each(Func &&func)
         {
@@ -170,7 +167,6 @@ namespace gamecoe
             pool->for_each(std::forward<Func>(func));
         }
 
-        // Iterates over all entities and their components and run func() on each of them
         template <typename T, typename Func>
         void for_each(Func &&func) const
         {

--- a/include/gamecoe/entity/entity.hpp
+++ b/include/gamecoe/entity/entity.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <cassert>
+#include <gamecoe/utils/error_handler.hpp>
 #include <limits>
 #include <compare>
 
@@ -9,6 +9,11 @@ namespace gamecoe
 {
     struct entity
     {
+        // 20-bit id, 12-bit generation: sized for object-pooling workloads (roughly 1M entities,
+        // ~4K generation-recycles per id) while keeping the whole handle at 4 bytes register-friendly.
+        // MAX_ENTITIES and MAX_GENERATIONS reserve the top value to avoid sentinel collision (see invalid()).
+        // Future: consider 32-bit id and separated 16-bit generation, 
+        // or 64-bit handles for larger games requiring more ids and generations (with custom separation within the 64-bits).
         static constexpr std::uint8_t ID_BITS = 20;
         static constexpr std::uint8_t GEN_BITS = 12;
         static constexpr std::uint32_t ID_MASK = (1U << ID_BITS) - 1;
@@ -16,6 +21,7 @@ namespace gamecoe
         static constexpr std::uint32_t MAX_ENTITIES = ID_MASK - 1;  // 1,048,574
         static constexpr std::uint16_t MAX_GENERATIONS = GEN_MASK - 1;  // 4,094
 
+        // All-1s bit pattern, this sentinel is why MAX_ENTITIES and MAX_GENERATIONS reserve the top value.
         static constexpr entity invalid() noexcept { return entity{std::numeric_limits<std::uint32_t>::max()}; }
 
         auto operator<=>(const entity &other) const noexcept = default;
@@ -26,10 +32,10 @@ namespace gamecoe
 
         static entity create(std::uint32_t id, std::uint16_t generation)
         {
-            assert(id <= MAX_ENTITIES && "entity::create(): entity id exceeds maximum");
-            assert(generation <= MAX_GENERATIONS && "entity::create(): entity generation exceeds maximum");
+            GAMECOE_ASSERT_LOG(id <= MAX_ENTITIES, "entity::create(): entity id exceeds maximum");
+            GAMECOE_ASSERT_LOG(generation <= MAX_GENERATIONS, "entity::create(): entity generation exceeds maximum");
             // Bit layout (id-major ensures default operator<=> orders by id first, generation second)
-            // [31..................12][11..............0] 
+            // [31..................12][11..............0]
             // [       20-bit id      ][12-bit generation]
             return entity((id << GEN_BITS) | generation);
         }

--- a/include/gamecoe/entity/extraction.hpp
+++ b/include/gamecoe/entity/extraction.hpp
@@ -9,6 +9,8 @@
 
 namespace gamecoe
 {
+    // Iterates the smallest pool first and checks membership in the rest via contains(),
+    // minimizing total contains() calls across the whole extraction.
     template <typename... Components>
     class extraction
     {
@@ -22,6 +24,10 @@ namespace gamecoe
             const extraction* m_extracted;
             std::size_t m_index;
 
+            // std::get<Is> needs a compile-time index, but which pool is smallest is only known
+            // at runtime (m_smallest_pool_index), so this loops over indices via a fold expression.
+            // has_all_components() below can stay type-keyed (a plain fold over Components) since
+            // it doesn't need to single out one specific pool.
             template <std::size_t... Is>
             entity get_current_entity(std::index_sequence<Is...>) const
             {
@@ -48,7 +54,7 @@ namespace gamecoe
                     entity e = get_current_entity(std::index_sequence_for<Components...>{});
 
                     if (has_all_components(e)) return;
-                    ++m_index; // entity e is not in all pools -> check the next one
+                    ++m_index; // entity e is not in all pools, check the next one
                 }
             }
 

--- a/include/gamecoe/entity/sparse_set.hpp
+++ b/include/gamecoe/entity/sparse_set.hpp
@@ -8,12 +8,17 @@
 #include <vector>
 #include <memory>
 #include <array>
+#include <gamecoe/utils/error_handler.hpp>
 
 namespace gamecoe
 {
     class sparse_set
     {
+        // PAGE_SIZE = 1024 matches 4KB OS page (1024 * sizeof(uint32_t) == 4096),
+        // balances memory waste vs pointer-chasing overhead.
         static constexpr std::uint16_t PAGE_SIZE = 1024;
+        // Mirrors entity::invalid()'s all-1s pattern,
+        // safe for the same reason (create() can never produce this exact value).
         static constexpr std::uint32_t TOMBSTONE = std::numeric_limits<std::uint32_t>::max();
 
         using page_type = std::array<std::uint32_t, PAGE_SIZE>;
@@ -22,6 +27,8 @@ namespace gamecoe
         std::vector<page_ptr_type> m_sparse;
         std::vector<entity> m_dense;
 
+        // Generation packed alongside dense index in the sparse array itself,
+        // so contains() never touches the dense array, pure cache win.
         std::uint16_t index_in_page(entity e) const noexcept { return e.id() % PAGE_SIZE; }
         std::uint32_t page_index(entity e) const noexcept { return e.id() / PAGE_SIZE; }
 
@@ -46,7 +53,7 @@ namespace gamecoe
         void insert(entity e)
         {
             if (contains(e)) return;
-            assert(m_dense.size() <= entity::MAX_ENTITIES && "sparse_set::insert(): max entities exceeded"); // sanity check
+            GAMECOE_ASSERT_LOG(m_dense.size() <= entity::MAX_ENTITIES, "sparse_set::insert(): max entities exceeded");
 
             auto page_i = page_index(e);
             if (page_i >= m_sparse.size()) 
@@ -76,12 +83,16 @@ namespace gamecoe
 
             (*page)[index_in_page(e)] = TOMBSTONE;
 
+            // When erasing the last dense element, swapped == e, and the sparse-page slot was already tombstoned above.
+            // Touching it again via swapped's page would write stale data.
             if (swapped == e) return;
             
             auto &swapped_page = m_sparse[page_index(swapped)];
             (*swapped_page)[index_in_page(swapped)] = pack_dense_index(dense_index, swapped.generation());
         }
 
+        // Mirrors erase() but skips entity-to-index lookup, used by component_pool::remove()
+        // which has already resolved the index and would otherwise pay for redundant lookup.
         void erase_at(std::uint32_t dense_index)
         {
             if (dense_index >= m_dense.size()) return;
@@ -119,7 +130,7 @@ namespace gamecoe
 
         entity get_entity_at_index(std::size_t index) const noexcept
         {
-            assert(index < m_dense.size() && "sparse_set::get_entity_at_index(): index out of bounds");
+            GAMECOE_ASSERT_LOG(index < m_dense.size(), "sparse_set::get_entity_at_index(): index out of bounds");
             return m_dense[index];
         }
 

--- a/include/gamecoe/utils/error_handler.hpp
+++ b/include/gamecoe/utils/error_handler.hpp
@@ -2,11 +2,15 @@
 
 #include <string>
 #include <stdexcept>
+#include <cassert>
 #include <gamecoe_config.hpp>
 
 #if GAMECOE_USE_LOGCOE
     #include <logcoe.hpp>
 #endif
+
+#define GAMECOE_ASSERT_LOG(condition, message) \
+    do { if (!(condition)) logcoe::error(message); assert((condition) && message); } while (0)
 
 namespace gamecoe
 {

--- a/src/gamecoe/entity/command_buffer.cpp
+++ b/src/gamecoe/entity/command_buffer.cpp
@@ -1,6 +1,12 @@
 #include <gamecoe/entity/command_buffer.hpp>
 #include <gamecoe/component/scene_tag.hpp>
-#include <cassert>
+#include <string>
+#include <gamecoe/utils/error_handler.hpp>
+#include <gamecoe_config.hpp>
+
+#if GAMECOE_USE_LOGCOE
+    #include <logcoe.hpp>
+#endif
 
 namespace gamecoe
 {
@@ -12,7 +18,7 @@ namespace gamecoe
 
     entity command_buffer::resolver::resolve(placeholder p) const
     {
-        assert(p.m_index < m_created.size() && "command_buffer::resolver::resolve(): placeholder out of range");
+        GAMECOE_ASSERT_LOG(p.m_index < m_created.size(), "command_buffer::resolver::resolve(): placeholder out of range");
         return m_created[p.m_index];
     }
 
@@ -40,6 +46,8 @@ namespace gamecoe
         resolver r(created);
         for (auto& cmd : m_commands)
             cmd(ents, r);
+
+        logcoe::info("command_buffer::flush(): flushed " + std::to_string(created.size()) + " entities");
 
         clear();
     }

--- a/src/gamecoe/entity/entities.cpp
+++ b/src/gamecoe/entity/entities.cpp
@@ -1,8 +1,13 @@
 #include <gamecoe/entity/entities.hpp>
 #include <gamecoe/component/transform.hpp>
 #include <gamecoe/component/parent_child.hpp>
-#include <cassert>
 #include <cstddef>
+#include <string>
+#include <gamecoe_config.hpp>
+
+#if GAMECOE_USE_LOGCOE
+    #include <logcoe.hpp>
+#endif
 
 namespace gamecoe
 {
@@ -16,7 +21,7 @@ namespace gamecoe
         if (m_recycle_ids.empty())
         {
             id = m_current_entity_id;
-            assert(id <= entity::MAX_ENTITIES && "entities::create(): entity limit reached");
+            GAMECOE_ASSERT_LOG(id <= entity::MAX_ENTITIES, "entities::create(): entity limit reached");
             m_current_entity_id++;
             generation = 0;
             m_generations.push_back(generation);
@@ -36,23 +41,27 @@ namespace gamecoe
 
     components::transform& entities::transform(entity e)
     {
-        assert(valid(e) && "entities::transform(): entity is not valid");
+        GAMECOE_ASSERT_LOG(valid(e), "entities::transform(): entity is not valid");
         components::transform* t = get_component<components::transform>(e);
-        assert(t && "entities::transform(): transform missing (should be impossible - mandatory component)");
+        GAMECOE_ASSERT_LOG(t != nullptr, "entities::transform(): transform missing (should be impossible - mandatory component)");
         return *t;
     }
 
     const components::transform& entities::transform(entity e) const
     {
-        assert(valid(e) && "entities::transform(): entity is not valid");
+        GAMECOE_ASSERT_LOG(valid(e), "entities::transform(): entity is not valid");
         const components::transform* t = get_component<components::transform>(e);
-        assert(t && "entities::transform(): transform missing (should be impossible - mandatory component)");
+        GAMECOE_ASSERT_LOG(t != nullptr, "entities::transform(): transform missing (should be impossible - mandatory component)");
         return *t;
     }
 
     void entities::destroy(entity e)
     {
-        if (!valid(e)) return;
+        if (!valid(e))
+        {
+            logcoe::debug("entities::destroy(): entity already invalid, ignoring");
+            return;
+        }
 
         std::vector<entity> to_destroy{ e };
         while (!to_destroy.empty())
@@ -83,6 +92,7 @@ namespace gamecoe
         m_recycle_ids.clear();
         m_generations.clear();
         m_current_entity_id = 0;
+        logcoe::info("entities::clear(): cleared all entities");
     }
 
     bool entities::valid(entity e) const
@@ -96,29 +106,35 @@ namespace gamecoe
         m_recycle_ids.reserve(capacity);
 
         for (auto &pool : m_pools) if (pool) pool->reserve(capacity);
+
+        logcoe::debug("entities::reserve(): reserved capacity for " + std::to_string(capacity) + " entities");
     }
 
     std::size_t entities::size() const
     {
-        assert(static_cast<std::size_t>(m_current_entity_id) >= m_recycle_ids.size());
+        GAMECOE_ASSERT_LOG(static_cast<std::size_t>(m_current_entity_id) >= m_recycle_ids.size(), "entities::size(): recycle count exceeds allocated id count");
         return static_cast<std::size_t>(m_current_entity_id) - m_recycle_ids.size();
     }
 
     void entities::set_parent(entity child, entity parent)
     {
-        assert(valid(child) && valid(parent) && "entities::set_parent(): child/parent must be valid entities");
-        assert(child != parent && "entities::set_parent(): entity cannot be its own parent");
+        GAMECOE_ASSERT_LOG(valid(child) && valid(parent), "entities::set_parent(): child/parent must be valid entities");
+        GAMECOE_ASSERT_LOG(child != parent, "entities::set_parent(): entity cannot be its own parent");
 
         auto parent_pool = get_pool<components::parent>();
         auto children_pool = get_pool<components::children>();
 
         if (parent_pool->contains(child) && parent_pool->get(child).handle == parent) return;
 
+        // Walk up from parent toward the root, checking whether child appears as its own ancestor.
+        // guard bounds the walk to entities.size() so a corrupted parent chain
+        // (shouldn't happen — set_parent blocks cycles at insertion) can't loop forever.
         entity ancestor = parent;
         std::size_t guard = 0;
-        while (guard < size())
+        const std::size_t max_guard = size();
+        while (guard < max_guard)
         {
-            assert(ancestor != child && "entities::set_parent(): would create a parent/child cycle");
+            GAMECOE_ASSERT_LOG(ancestor != child, "entities::set_parent(): would create a parent/child cycle");
             // Only relevant in release mode - we should have already caught cycles via the assert above in debug builds
             if (ancestor == child) return;
             if (!parent_pool->contains(ancestor)) break;
@@ -144,6 +160,8 @@ namespace gamecoe
         {
             auto children_pool = get_pool<components::children>();
             std::erase(children_pool->get(old_parent).handles, child);
+            // A childless entity has no children component at all, not one with an empty list -
+            // so has_component<children>(e) alone tells you whether an entity has any children.
             if (!children_pool->get(old_parent).has_children()) children_pool->remove(old_parent);
         }
 


### PR DESCRIPTION
This is a one-time catch-up pass over that existing code so the check has a clean baseline going forward.

- Add WHY-only comments across the entity core (entity, sparse_set, component_pool, entities,
  extraction) and command_buffer
- Add WHY comments to transform's local_matrix, collision_callbacks' dual-registry parameter shape, and scene_id
- Add logging to entities and command_buffer's public API through logcoe
- Add a GAMECOE_ASSERT_LOG macro pairing a debug assert with an always-on logcoe::error call
- Convert every runtime assert across the entity, component, and core DoD ECS files to GAMECOE_ASSERT_LOG