### PR TITLE
[Core]: Implement active/inactive entity partition for component pools

### DIFF
--- a/include/gamecoe/entity/component_pool.hpp
+++ b/include/gamecoe/entity/component_pool.hpp
@@ -125,7 +125,7 @@ namespace gamecoe
         }
 
         template <typename... Args>
-        T& add(entity e, Args&&... args)
+        T& add(entity e, bool active, Args&&... args)
         {
             if (contains(e))
             {
@@ -133,7 +133,7 @@ namespace gamecoe
                 // Release has no assert, so we overwrite instead of silently discarding the caller's new value.
                 T &existing = m_components[m_entities.index(e).value()];
                 existing = T(std::forward<Args>(args)...);
-                return existing;
+                return existing;   // active untouched - an existing entity's state isn't this call's business
             }
 
             // sparse_set::insert() appends then swaps the new entity down into the active partition,
@@ -146,7 +146,9 @@ namespace gamecoe
 
             if (target_index != back_index) std::swap(m_components[target_index], m_components[back_index]);
 
-            return m_components[target_index];
+            if (!active) deactivate(e);   // may relocate the entry again - re-resolve below either way
+
+            return get(e);
         }
 
         // Asserts and returns T& (not nullable), callers here already checked contains().

--- a/include/gamecoe/entity/component_pool.hpp
+++ b/include/gamecoe/entity/component_pool.hpp
@@ -18,6 +18,9 @@ namespace gamecoe
         // so neither one can be forgotten.
         virtual void do_reserve(std::size_t capacity) = 0;
 
+        // Derived mirrors the dense-array swap sparse_set performs internally onto its own parallel array.
+        virtual void swap_components(std::uint32_t a, std::uint32_t b) = 0;
+
     public:
         virtual ~basic_component_pool() = default;
         virtual void remove(entity e) = 0;
@@ -27,6 +30,45 @@ namespace gamecoe
         std::size_t size() const noexcept { return m_entities.size(); }
         bool empty() const noexcept { return m_entities.empty(); }
         void reserve(std::size_t capacity) { m_entities.reserve(capacity); do_reserve(capacity); }
+
+        std::size_t active_size() const noexcept { return m_entities.active_size(); }
+
+        bool is_active(entity e) const noexcept
+        {
+            auto index = m_entities.index(e);
+            return index && m_entities.is_active(index.value());   // absent entity -> false, mirrors contains()
+        }
+
+        // Every pool an entity belongs to must agree on its active state - see entities::activate()/
+        // deactivate(), which is the only caller that maintains that across all pools.
+        void deactivate(entity e)
+        {
+            auto index = m_entities.index(e);
+            if (!index) return;
+
+            std::uint32_t i = index.value();
+            if (!m_entities.is_active(i)) return;                                  // already inactive
+
+            // active_size() and i must be captured before deactivate_at(), since that call changes active_count.
+            std::uint32_t last_active = static_cast<std::uint32_t>(m_entities.active_size()) - 1;
+            m_entities.deactivate_at(i);                                           // moves e past the active/inactive boundary
+            if (i != last_active) swap_components(i, last_active);
+        }
+
+        // See deactivate() above for the shared active-state invariant this mirrors.
+        void activate(entity e)
+        {
+            auto index = m_entities.index(e);
+            if (!index) return;
+
+            std::uint32_t i = index.value();
+            if (m_entities.is_active(i)) return;                                   // already active
+
+            // active_size() and i must be captured before activate_at(), since that call changes active_count.
+            std::uint32_t first_inactive = static_cast<std::uint32_t>(m_entities.active_size());
+            m_entities.activate_at(i);                                             // moves e past the active/inactive boundary
+            if (i != first_inactive) swap_components(i, first_inactive);
+        }
 
         entity get_entity_at_index(std::size_t index) const noexcept { return m_entities.get_entity_at_index(index); }
     };
@@ -41,6 +83,8 @@ namespace gamecoe
             m_components.reserve(capacity);
         }
 
+        void swap_components(std::uint32_t a, std::uint32_t b) override { std::swap(m_components[a], m_components[b]); }
+
     public:
         component_pool() noexcept = default;
         component_pool(const component_pool&) = delete;
@@ -53,14 +97,24 @@ namespace gamecoe
         void remove(entity e) override
         {
             auto index = m_entities.index(e);
-            if(!index) return;
+            if (!index) return;
 
-            std::uint32_t i = index.value();
-            m_entities.erase_at(i);
+            std::uint32_t i      = index.value();
+            std::uint32_t last   = static_cast<std::uint32_t>(m_components.size()) - 1;
+            std::uint32_t active = static_cast<std::uint32_t>(m_entities.active_size());
 
-            if (i != m_components.size() - 1)
-                m_components[i] = std::move(m_components.back());
+            m_entities.erase_at(i);   // performs the boundary swap (if any) + swap-with-back + active_count fixup
 
+            // Mirror erase_at()'s first swap: route the removed entry out through the active boundary.
+            if (i < active)
+            {
+                std::uint32_t last_active = active - 1;
+                if (i != last_active) m_components[i] = std::move(m_components[last_active]);   // guard: no self-move
+                i = last_active;
+            }
+
+            // Mirror erase_at()'s swap-with-back.
+            if (i != last) m_components[i] = std::move(m_components[last]);
             m_components.pop_back();
         }
 
@@ -82,10 +136,17 @@ namespace gamecoe
                 return existing;
             }
 
-            m_entities.insert(e);
-            m_components.emplace_back(std::forward<Args>(args)...);
+            // sparse_set::insert() appends then swaps the new entity down into the active partition,
+            // so the component can't just be left at the back - mirror the same swap.
+            const std::uint32_t back_index   = static_cast<std::uint32_t>(m_components.size());
+            const std::uint32_t target_index = static_cast<std::uint32_t>(m_entities.active_size());
 
-            return m_components.back();
+            m_components.emplace_back(std::forward<Args>(args)...);   // emplace first: if it throws, m_entities is untouched
+            m_entities.insert(e);
+
+            if (target_index != back_index) std::swap(m_components[target_index], m_components[back_index]);
+
+            return m_components[target_index];
         }
 
         // Asserts and returns T& (not nullable), callers here already checked contains().

--- a/include/gamecoe/entity/component_pool.hpp
+++ b/include/gamecoe/entity/component_pool.hpp
@@ -36,7 +36,7 @@ namespace gamecoe
         bool is_active(entity e) const noexcept
         {
             auto index = m_entities.index(e);
-            return index && m_entities.is_active(index.value());   // absent entity -> false, mirrors contains()
+            return index && m_entities.is_active(index.value());
         }
 
         // Every pool an entity belongs to must agree on its active state - see entities::activate()/
@@ -47,27 +47,18 @@ namespace gamecoe
             if (!index) return;
 
             std::uint32_t i = index.value();
-            if (!m_entities.is_active(i)) return;                                  // already inactive
-
-            // active_size() and i must be captured before deactivate_at(), since that call changes active_count.
-            std::uint32_t last_active = static_cast<std::uint32_t>(m_entities.active_size()) - 1;
-            m_entities.deactivate_at(i);                                           // moves e past the active/inactive boundary
-            if (i != last_active) swap_components(i, last_active);
+            if (auto partner = m_entities.deactivate_at(i); partner && partner.value() != i)
+                swap_components(i, partner.value());
         }
 
-        // See deactivate() above for the shared active-state invariant this mirrors.
         void activate(entity e)
         {
             auto index = m_entities.index(e);
             if (!index) return;
 
             std::uint32_t i = index.value();
-            if (m_entities.is_active(i)) return;                                   // already active
-
-            // active_size() and i must be captured before activate_at(), since that call changes active_count.
-            std::uint32_t first_inactive = static_cast<std::uint32_t>(m_entities.active_size());
-            m_entities.activate_at(i);                                             // moves e past the active/inactive boundary
-            if (i != first_inactive) swap_components(i, first_inactive);
+            if (auto partner = m_entities.activate_at(i); partner && partner.value() != i)
+                swap_components(i, partner.value());
         }
 
         entity get_entity_at_index(std::size_t index) const noexcept { return m_entities.get_entity_at_index(index); }
@@ -99,21 +90,13 @@ namespace gamecoe
             auto index = m_entities.index(e);
             if (!index) return;
 
-            std::uint32_t i      = index.value();
-            std::uint32_t last   = static_cast<std::uint32_t>(m_components.size()) - 1;
-            std::uint32_t active = static_cast<std::uint32_t>(m_entities.active_size());
+            deactivate(e);   // No-op if e is already inactive. Otherwise moves e (and its component) to the first-inactive slot.
 
-            m_entities.erase_at(i);   // performs the boundary swap (if any) + swap-with-back + active_count fixup
+            std::uint32_t i    = m_entities.index(e).value();   // re-resolve: deactivate() may have moved it
+            std::uint32_t last = static_cast<std::uint32_t>(m_components.size()) - 1;
 
-            // Mirror erase_at()'s first swap: route the removed entry out through the active boundary.
-            if (i < active)
-            {
-                std::uint32_t last_active = active - 1;
-                if (i != last_active) m_components[i] = std::move(m_components[last_active]);   // guard: no self-move
-                i = last_active;
-            }
+            m_entities.erase_at(i);   // both endpoints are now inactive, so this is a pure swap-with-back + pop
 
-            // Mirror erase_at()'s swap-with-back.
             if (i != last) m_components[i] = std::move(m_components[last]);
             m_components.pop_back();
         }
@@ -133,22 +116,23 @@ namespace gamecoe
                 // Release has no assert, so we overwrite instead of silently discarding the caller's new value.
                 T &existing = m_components[m_entities.index(e).value()];
                 existing = T(std::forward<Args>(args)...);
-                return existing;   // active untouched - an existing entity's state isn't this call's business
+                return existing;   // active is ignored when the entity already exists. An existing entry keeps its current state.
             }
 
-            // sparse_set::insert() appends then swaps the new entity down into the active partition,
-            // so the component can't just be left at the back - mirror the same swap.
             const std::uint32_t back_index   = static_cast<std::uint32_t>(m_components.size());
             const std::uint32_t target_index = static_cast<std::uint32_t>(m_entities.active_size());
 
             m_components.emplace_back(std::forward<Args>(args)...);   // emplace first: if it throws, m_entities is untouched
-            m_entities.insert(e);
+            m_entities.insert(e, active);
+
+            // An inactive entry stays at the back, where both arrays already agree. An active one is
+            // swapped down into the boundary slot by insert(), so mirror that swap here to keep
+            // m_components[i] paired with the entity at dense index i.
+            if (!active) return m_components[back_index];
 
             if (target_index != back_index) std::swap(m_components[target_index], m_components[back_index]);
 
-            if (!active) deactivate(e);   // may relocate the entry again - re-resolve below either way
-
-            return get(e);
+            return m_components[target_index];
         }
 
         // Asserts and returns T& (not nullable), callers here already checked contains().
@@ -187,8 +171,7 @@ namespace gamecoe
                 func(m_entities.get_entity_at_index(i), m_components[i]);
         }
 
-        // Full scan over both partitions, for callers that need every entity regardless of
-        // active state.
+        // Full scan over both partitions, unlike for_each().
         template<typename Func>
         void for_each_all(Func &&func)
         {

--- a/include/gamecoe/entity/component_pool.hpp
+++ b/include/gamecoe/entity/component_pool.hpp
@@ -169,10 +169,12 @@ namespace gamecoe
             return m_components[index.value()];
         }
 
+        // Active partition only - a deactivated entity (e.g. one in a paused scene) is skipped,
+        // same bound extract<>() uses.
         template<typename Func>
         void for_each(Func &&func)
         {
-            auto size = m_components.size();
+            auto size = active_size();
             for(std::size_t i = 0; i < size; ++i)
                 func(m_entities.get_entity_at_index(i), m_components[i]);
         }
@@ -180,12 +182,31 @@ namespace gamecoe
         template<typename Func>
         void for_each(Func &&func) const
         {
+            auto size = active_size();
+            for(std::size_t i = 0; i < size; ++i)
+                func(m_entities.get_entity_at_index(i), m_components[i]);
+        }
+
+        // Full scan over both partitions, for callers that need every entity regardless of
+        // active state.
+        template<typename Func>
+        void for_each_all(Func &&func)
+        {
             auto size = m_components.size();
             for(std::size_t i = 0; i < size; ++i)
                 func(m_entities.get_entity_at_index(i), m_components[i]);
         }
 
-        // Iterators invalidated by add/remove (dense array reallocation)
+        template<typename Func>
+        void for_each_all(Func &&func) const
+        {
+            auto size = m_components.size();
+            for(std::size_t i = 0; i < size; ++i)
+                func(m_entities.get_entity_at_index(i), m_components[i]);
+        }
+
+        // Iterators invalidated by add/remove (dense array reallocation). Span both partitions
+        // (active and inactive) - for active-only iteration use for_each()/extract() instead.
         T *begin() noexcept { return m_components.data(); }
         T *end() noexcept { return m_components.data() + m_components.size(); }
         const T *begin() const noexcept { return m_components.data(); }

--- a/include/gamecoe/entity/component_pool.hpp
+++ b/include/gamecoe/entity/component_pool.hpp
@@ -137,6 +137,8 @@ namespace gamecoe
 
         // Asserts and returns T& (not nullable), callers here already checked contains().
         // entities::get_component<T>() returns a nullable pointer instead since its callers don't always know.
+        // try_get() below is for callers in neither position: they haven't already checked contains(),
+        // but want the single lookup either way instead of a separate contains() + get() pair.
         T& get(entity e)
         {
             auto index = m_entities.index(e);
@@ -153,8 +155,23 @@ namespace gamecoe
             return m_components[index.value()];
         }
 
+        // Single lookup, nullable - for callers that don't already know the entity is present
+        // (unlike get(), which asserts and is for callers that already checked contains()).
+        T* try_get(entity e)
+        {
+            auto index = m_entities.index(e);
+            return index ? &m_components[index.value()] : nullptr;
+        }
+
+        const T* try_get(entity e) const
+        {
+            auto index = m_entities.index(e);
+            return index ? &m_components[index.value()] : nullptr;
+        }
+
         // Active partition only - a deactivated entity (e.g. one in a paused scene) is skipped,
-        // same bound extract<>() uses.
+        // same bound extract<>() uses. Activating/deactivating an entity from inside the callback
+        // reorders the dense array mid-loop, same hazard as extraction (see extraction.hpp).
         template<typename Func>
         void for_each(Func &&func)
         {
@@ -171,7 +188,8 @@ namespace gamecoe
                 func(m_entities.get_entity_at_index(i), m_components[i]);
         }
 
-        // Full scan over both partitions, unlike for_each().
+        // Full scan over both partitions, unlike for_each(). Mutating any pool (activate/deactivate/add/remove)
+        // during iteration invalidates the cached bound (see begin()/end() comment).
         template<typename Func>
         void for_each_all(Func &&func)
         {

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -88,7 +88,8 @@ namespace gamecoe
 
         // Pool-unlink half of remove_parent(), with no active-state recompute - set_parent()
         // calls it directly so re-parenting recomputes once.
-        void unlink_parent(entity child);
+        // Returns true if child had a parent link that was removed, false if it had none.
+        bool unlink_parent(entity child);
 
     public:
         entities() = default;

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -59,11 +59,35 @@ namespace gamecoe
             return static_cast<component_pool<T>*>(m_pools[comp_id].get());
         }
 
+        // Non-creating lookup - nullptr if T's pool doesn't exist yet. The const-safe
+        // counterpart to get_pool<T>() above, for callers that must not mutate m_pools.
+        template <typename T>
+        component_pool<T>* find_pool()
+        {
+            std::uint32_t comp_id = component_id<T>();
+            if (comp_id >= m_pools.size() || !m_pools[comp_id]) return nullptr;
+            return static_cast<component_pool<T>*>(m_pools[comp_id].get());
+        }
+
+        template <typename T>
+        const component_pool<T>* find_pool() const
+        {
+            std::uint32_t comp_id = component_id<T>();
+            if (comp_id >= m_pools.size() || !m_pools[comp_id]) return nullptr;
+            return static_cast<const component_pool<T>*>(m_pools[comp_id].get());
+        }
+
         // Applies world_active to e and cascades to its subtree per each descendant's own self_active.
         void set_active(entity e, bool world_active);
 
-        // Pool-unlink step of remove_parent() only, no active-state recompute - lets set_parent()
-        // call this directly when re-parenting, instead of recomputing active state twice.
+        // self_active AND (no parent OR the parent's own world-active state) - the formula every
+        // hierarchy-aware active-state recompute in this file is built on. Reads e's *current*
+        // self_active and parent link, so callers update those first if this call means to reflect
+        // a change (e.g. activate() sets m_self_active[e.id()] = true before calling this).
+        bool compute_world_active(entity e);
+
+        // Pool-unlink half of remove_parent(), with no active-state recompute - set_parent()
+        // calls it directly so re-parenting recomputes once.
         void unlink_parent(entity child);
 
     public:
@@ -117,10 +141,8 @@ namespace gamecoe
         {
             if (!valid(e)) return false;
 
-            std::uint32_t comp_id = component_id<T>();
-            if (comp_id >= m_pools.size() || !m_pools[comp_id]) return false;
-
-            return m_pools[comp_id]->contains(e);
+            auto pool = find_pool<T>();
+            return pool && pool->contains(e);
         }
 
         // No-op if e doesn't have T, or e is invalid.
@@ -175,41 +197,29 @@ namespace gamecoe
         template <typename T, typename Func>
         void for_each(Func &&func)
         {
-            std::uint32_t comp_id = component_id<T>();
-            if (comp_id >= m_pools.size() || !m_pools[comp_id]) return;
-
-            auto pool = static_cast<component_pool<T>*>(m_pools[comp_id].get());
-            pool->for_each(std::forward<Func>(func));
+            auto pool = find_pool<T>();
+            if (pool) pool->for_each(std::forward<Func>(func));
         }
 
         template <typename T, typename Func>
         void for_each(Func &&func) const
         {
-            std::uint32_t comp_id = component_id<T>();
-            if (comp_id >= m_pools.size() || !m_pools[comp_id]) return;
-
-            auto pool = static_cast<const component_pool<T>*>(m_pools[comp_id].get());
-            pool->for_each(std::forward<Func>(func));
+            auto pool = find_pool<T>();
+            if (pool) pool->for_each(std::forward<Func>(func));
         }
 
         template <typename T, typename Func>
         void for_each_all(Func &&func)
         {
-            std::uint32_t comp_id = component_id<T>();
-            if (comp_id >= m_pools.size() || !m_pools[comp_id]) return;
-
-            auto pool = static_cast<component_pool<T>*>(m_pools[comp_id].get());
-            pool->for_each_all(std::forward<Func>(func));
+            auto pool = find_pool<T>();
+            if (pool) pool->for_each_all(std::forward<Func>(func));
         }
 
         template <typename T, typename Func>
         void for_each_all(Func &&func) const
         {
-            std::uint32_t comp_id = component_id<T>();
-            if (comp_id >= m_pools.size() || !m_pools[comp_id]) return;
-
-            auto pool = static_cast<const component_pool<T>*>(m_pools[comp_id].get());
-            pool->for_each_all(std::forward<Func>(func));
+            auto pool = find_pool<T>();
+            if (pool) pool->for_each_all(std::forward<Func>(func));
         }
 
         template <typename... Components>

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -34,6 +34,8 @@ namespace gamecoe
         std::vector<std::unique_ptr<basic_component_pool>> m_pools;
         std::vector<std::uint32_t> m_recycle_ids;
         std::vector<std::uint16_t> m_generations;
+        // Per-entity activate()/deactivate() request, independent of any inherited parent state.
+        std::vector<bool> m_self_active;
 
         std::uint32_t m_current_entity_id{0};
 
@@ -57,6 +59,13 @@ namespace gamecoe
             return static_cast<component_pool<T>*>(m_pools[comp_id].get());
         }
 
+        // Applies world_active to e and cascades to its subtree per each descendant's own self_active.
+        void set_active(entity e, bool world_active);
+
+        // Pool-unlink step of remove_parent() only, no active-state recompute - lets set_parent()
+        // call this directly when re-parenting, instead of recomputing active state twice.
+        void unlink_parent(entity child);
+
     public:
         entities() = default;
         entities(const entities&) = delete;
@@ -71,6 +80,12 @@ namespace gamecoe
 
         // No-op if e is already invalid.
         void destroy(entity e);
+
+        // activate()/deactivate()/is_active() read and move the same active/inactive partition
+        // that extract() and for_each() iterate over.
+        void activate(entity e);
+        void deactivate(entity e);
+        bool is_active(entity e) const;
 
         void clear();
 
@@ -93,7 +108,7 @@ namespace gamecoe
             GAMECOE_ASSERT_LOG(valid(e), "entities::add_component(): entity is not valid");
 
             auto pool = get_pool<T>();
-            return pool->add(e, true, std::forward<Args>(args)...);
+            return pool->add(e, is_active(e), std::forward<Args>(args)...);
         }
 
         // Safe on an invalid entity, returns false rather than asserting.

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -93,7 +93,7 @@ namespace gamecoe
             GAMECOE_ASSERT_LOG(valid(e), "entities::add_component(): entity is not valid");
 
             auto pool = get_pool<T>();
-            return pool->add(e, std::forward<Args>(args)...);
+            return pool->add(e, true, std::forward<Args>(args)...);
         }
 
         // Safe on an invalid entity, returns false rather than asserting.

--- a/include/gamecoe/entity/entities.hpp
+++ b/include/gamecoe/entity/entities.hpp
@@ -192,6 +192,26 @@ namespace gamecoe
             pool->for_each(std::forward<Func>(func));
         }
 
+        template <typename T, typename Func>
+        void for_each_all(Func &&func)
+        {
+            std::uint32_t comp_id = component_id<T>();
+            if (comp_id >= m_pools.size() || !m_pools[comp_id]) return;
+
+            auto pool = static_cast<component_pool<T>*>(m_pools[comp_id].get());
+            pool->for_each_all(std::forward<Func>(func));
+        }
+
+        template <typename T, typename Func>
+        void for_each_all(Func &&func) const
+        {
+            std::uint32_t comp_id = component_id<T>();
+            if (comp_id >= m_pools.size() || !m_pools[comp_id]) return;
+
+            auto pool = static_cast<const component_pool<T>*>(m_pools[comp_id].get());
+            pool->for_each_all(std::forward<Func>(func));
+        }
+
         template <typename... Components>
         extraction<Components...> extract()
         {

--- a/include/gamecoe/entity/extraction.hpp
+++ b/include/gamecoe/entity/extraction.hpp
@@ -9,7 +9,7 @@
 
 namespace gamecoe
 {
-    // Iterates the smallest pool's active partition first and checks membership in the rest via
+    // Iterates the smallest pool's active partition and checks membership in the rest via
     // contains(), minimizing total contains() calls across the whole extraction. Mutating any
     // pool (activate/deactivate/add/remove) during iteration invalidates the cached bound.
     template <typename... Components>
@@ -37,7 +37,7 @@ namespace gamecoe
                 entity e = entity::invalid();
 
                 ((Is == m_extracted->m_smallest_pool_index ?
-                    (e = std::get<Is>(m_extracted->m_pools)->get_entity_at_index(m_index), true) : false) 
+                    (e = std::get<Is>(m_extracted->m_pools)->get_entity_at_index(m_index), true) : false)
                 || ...);
 
                 return e;

--- a/include/gamecoe/entity/extraction.hpp
+++ b/include/gamecoe/entity/extraction.hpp
@@ -9,8 +9,9 @@
 
 namespace gamecoe
 {
-    // Iterates the smallest pool first and checks membership in the rest via contains(),
-    // minimizing total contains() calls across the whole extraction.
+    // Iterates the smallest pool's active partition first and checks membership in the rest via
+    // contains(), minimizing total contains() calls across the whole extraction. Mutating any
+    // pool (activate/deactivate/add/remove) during iteration invalidates the cached bound.
     template <typename... Components>
     class extraction
     {
@@ -86,7 +87,7 @@ namespace gamecoe
 
         explicit extraction(component_pool<std::remove_const_t<Components>>*... pools) : m_pools(pools...)
         {
-            std::size_t sizes[] = { pools->size()... };
+            std::size_t sizes[] = { pools->active_size()... };
 
             m_smallest_pool_index = 0;
             m_smallest_pool_size = sizes[0];

--- a/include/gamecoe/entity/sparse_set.hpp
+++ b/include/gamecoe/entity/sparse_set.hpp
@@ -41,12 +41,12 @@ namespace gamecoe
             return (generation << entity::ID_BITS) | dense_index;
         }
 
-        // Swaps two dense slots and repoints both sparse entries. 
-        // Safe when a == b (writes the same packed value twice). 
-        // Pages are guaranteed live: both slots hold entities currently in m_dense, 
-        // so their pages were allocated by insert().
+        // Swaps two dense slots and repoints both sparse entries. A self-swap is a no-op: the
+        // sparse entry already names slot a. Pages are guaranteed live: both slots hold entities
+        // currently in m_dense, so their pages were allocated by insert().
         void swap_dense(std::uint32_t a, std::uint32_t b) noexcept
         {
+            if (a == b) return;
             std::swap(m_dense[a], m_dense[b]);
             entity ea = m_dense[a];
             entity eb = m_dense[b];
@@ -74,27 +74,29 @@ namespace gamecoe
 
         void reserve(std::size_t capacity) { m_dense.reserve(capacity); }
 
-        void insert(entity e)
+        // A new entry is appended at the back, which the active_count <= size invariant guarantees
+        // is at or past the active/inactive boundary - so an inactive insert is a plain append, and
+        // only the active path pays for a swap down into the active partition.
+        void insert(entity e, bool active)
         {
             if (contains(e)) return;
             GAMECOE_ASSERT_LOG(m_dense.size() <= entity::MAX_ENTITIES, "sparse_set::insert(): max entities exceeded");
 
             auto page_i = page_index(e);
-            if (page_i >= m_sparse.size()) 
+            if (page_i >= m_sparse.size())
                 m_sparse.resize(page_i + 1);
 
             auto &page = m_sparse[page_i];
-            if (!page) 
+            if (!page)
             {
                 page = std::make_unique<page_type>();
                 page->fill(TOMBSTONE);
             }
-            
+
             (*page)[index_in_page(e)] = pack_dense_index(static_cast<std::uint32_t>(m_dense.size()), e.generation());
             m_dense.push_back(e);
 
-            // Entities are active by default when inserted.
-            activate_at(static_cast<std::uint32_t>(m_dense.size() - 1));
+            if (active) activate_at(static_cast<std::uint32_t>(m_dense.size() - 1));
         }
 
         // Mirrors erase() but skips entity-to-index lookup, used by component_pool::remove()
@@ -103,15 +105,10 @@ namespace gamecoe
         {
             if (dense_index >= m_dense.size()) return;
 
-            // Move the entity out of the active partition first (the same swap deactivate does), so the
-            // swap-with-back below can never drop an inactive entity into an active slot.
-            if (dense_index < m_active_count)
-            {
-                deactivate_at(dense_index);
-                dense_index = m_active_count;   // deactivate_at() left it in the first inactive slot
-            }
+            // Route an active entry out through the boundary first, so the swap-with-back below
+            // can never drop an inactive entity into an active slot.
+            if (auto partner = deactivate_at(dense_index)) dense_index = partner.value();
 
-            // Both endpoints are now inactive, so the swap-with-back below can never disturb the active partition.
             entity e = m_dense[dense_index];
             auto page_i = page_index(e);
             auto i_in_page = index_in_page(e);
@@ -136,22 +133,24 @@ namespace gamecoe
         void deactivate(entity e) { if (auto i = index(e)) deactivate_at(i.value()); }
         void activate(entity e)   { if (auto i = index(e)) activate_at(i.value()); }
 
-        // Index-taking forms mirror erase_at(): used by component_pool, which has already
-        // resolved the index and would otherwise pay for a redundant lookup.
-        void deactivate_at(std::uint32_t dense_index)
+        // Returns the dense index the entry was swapped with, or nullopt if it was already in the target state.
+        std::optional<std::uint32_t> deactivate_at(std::uint32_t dense_index)
         {
             GAMECOE_ASSERT_LOG(dense_index < m_dense.size(), "sparse_set::deactivate_at(): index out of bounds");
-            if (dense_index >= m_active_count) return;   // already inactive
+            if (dense_index >= m_active_count) return std::nullopt;   // already inactive
             --m_active_count;
             swap_dense(dense_index, m_active_count);     // m_active_count now names the old last-active slot
+            return m_active_count;
         }
 
-        void activate_at(std::uint32_t dense_index)
+        std::optional<std::uint32_t> activate_at(std::uint32_t dense_index)
         {
             GAMECOE_ASSERT_LOG(dense_index < m_dense.size(), "sparse_set::activate_at(): index out of bounds");
-            if (dense_index < m_active_count) return;    // already active
-            swap_dense(dense_index, m_active_count);     // m_active_count names the first inactive slot
+            if (dense_index < m_active_count) return std::nullopt;    // already active
+            std::uint32_t partner = m_active_count;
+            swap_dense(dense_index, partner);            // m_active_count names the first inactive slot
             ++m_active_count;
+            return partner;
         }
 
         std::optional<std::uint32_t> index(entity e) const
@@ -162,10 +161,10 @@ namespace gamecoe
         }
 
         bool contains(entity e) const noexcept
-        { 
+        {
             auto page_i = page_index(e);
 
-            return page_i < m_sparse.size() && m_sparse[page_i] && 
+            return page_i < m_sparse.size() && m_sparse[page_i] &&
                    unpack_generation((*m_sparse[page_i])[index_in_page(e)]) == e.generation();
         }
 

--- a/include/gamecoe/entity/sparse_set.hpp
+++ b/include/gamecoe/entity/sparse_set.hpp
@@ -137,6 +137,7 @@ namespace gamecoe
         std::optional<std::uint32_t> deactivate_at(std::uint32_t dense_index)
         {
             GAMECOE_ASSERT_LOG(dense_index < m_dense.size(), "sparse_set::deactivate_at(): index out of bounds");
+            if (dense_index >= m_dense.size()) return std::nullopt;   // release-mode only - debug already caught it via the assert above
             if (dense_index >= m_active_count) return std::nullopt;   // already inactive
             --m_active_count;
             swap_dense(dense_index, m_active_count);     // m_active_count now names the old last-active slot
@@ -146,6 +147,7 @@ namespace gamecoe
         std::optional<std::uint32_t> activate_at(std::uint32_t dense_index)
         {
             GAMECOE_ASSERT_LOG(dense_index < m_dense.size(), "sparse_set::activate_at(): index out of bounds");
+            if (dense_index >= m_dense.size()) return std::nullopt;   // release-mode only - debug already caught it via the assert above
             if (dense_index < m_active_count) return std::nullopt;    // already active
             std::uint32_t partner = m_active_count;
             swap_dense(dense_index, partner);            // m_active_count names the first inactive slot

--- a/include/gamecoe/entity/sparse_set.hpp
+++ b/include/gamecoe/entity/sparse_set.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <memory>
 #include <array>
+#include <utility>
 #include <gamecoe/utils/error_handler.hpp>
 
 namespace gamecoe
@@ -26,6 +27,7 @@ namespace gamecoe
 
         std::vector<page_ptr_type> m_sparse;
         std::vector<entity> m_dense;
+        std::uint32_t m_active_count{0};
 
         // Generation packed alongside dense index in the sparse array itself,
         // so contains() never touches the dense array, pure cache win.
@@ -38,13 +40,35 @@ namespace gamecoe
         {
             return (generation << entity::ID_BITS) | dense_index;
         }
-        
+
+        // Swaps two dense slots and repoints both sparse entries. 
+        // Safe when a == b (writes the same packed value twice). 
+        // Pages are guaranteed live: both slots hold entities currently in m_dense, 
+        // so their pages were allocated by insert().
+        void swap_dense(std::uint32_t a, std::uint32_t b) noexcept
+        {
+            std::swap(m_dense[a], m_dense[b]);
+            entity ea = m_dense[a];
+            entity eb = m_dense[b];
+            (*m_sparse[page_index(ea)])[index_in_page(ea)] = pack_dense_index(a, ea.generation());
+            (*m_sparse[page_index(eb)])[index_in_page(eb)] = pack_dense_index(b, eb.generation());
+        }
+
     public:
         sparse_set() noexcept = default;
         sparse_set(const sparse_set&) = delete;
         sparse_set& operator=(const sparse_set&) = delete;
-        sparse_set(sparse_set&&) noexcept = default;
-        sparse_set& operator=(sparse_set&&) noexcept = default;
+        sparse_set(sparse_set&& other) noexcept
+            : m_sparse(std::move(other.m_sparse)), m_dense(std::move(other.m_dense)),
+              m_active_count(std::exchange(other.m_active_count, 0)) {}
+
+        sparse_set& operator=(sparse_set&& other) noexcept
+        {
+            m_sparse = std::move(other.m_sparse);
+            m_dense = std::move(other.m_dense);
+            m_active_count = std::exchange(other.m_active_count, 0);
+            return *this;
+        }
 
         ~sparse_set() = default;
 
@@ -68,27 +92,9 @@ namespace gamecoe
             
             (*page)[index_in_page(e)] = pack_dense_index(static_cast<std::uint32_t>(m_dense.size()), e.generation());
             m_dense.push_back(e);
-        }
 
-        void erase(entity e)
-        {
-            if (!contains(e)) return;
-
-            auto &page = m_sparse[page_index(e)];
-            auto dense_index = unpack_dense_index((*page)[index_in_page(e)]);
-
-            auto swapped = m_dense.back();
-            m_dense[dense_index] = swapped;
-            m_dense.pop_back();
-
-            (*page)[index_in_page(e)] = TOMBSTONE;
-
-            // When erasing the last dense element, swapped == e, and the sparse-page slot was already tombstoned above.
-            // Touching it again via swapped's page would write stale data.
-            if (swapped == e) return;
-            
-            auto &swapped_page = m_sparse[page_index(swapped)];
-            (*swapped_page)[index_in_page(swapped)] = pack_dense_index(dense_index, swapped.generation());
+            // Entities are active by default when inserted.
+            activate_at(static_cast<std::uint32_t>(m_dense.size() - 1));
         }
 
         // Mirrors erase() but skips entity-to-index lookup, used by component_pool::remove()
@@ -97,6 +103,15 @@ namespace gamecoe
         {
             if (dense_index >= m_dense.size()) return;
 
+            // Move the entity out of the active partition first (the same swap deactivate does), so the
+            // swap-with-back below can never drop an inactive entity into an active slot.
+            if (dense_index < m_active_count)
+            {
+                deactivate_at(dense_index);
+                dense_index = m_active_count;   // deactivate_at() left it in the first inactive slot
+            }
+
+            // Both endpoints are now inactive, so the swap-with-back below can never disturb the active partition.
             entity e = m_dense[dense_index];
             auto page_i = page_index(e);
             auto i_in_page = index_in_page(e);
@@ -111,6 +126,32 @@ namespace gamecoe
 
             auto &swapped_page = m_sparse[page_index(swapped)];
             (*swapped_page)[index_in_page(swapped)] = pack_dense_index(dense_index, swapped.generation());
+        }
+
+        void erase(entity e) { if (auto i = index(e)) erase_at(i.value()); }
+
+        std::size_t active_size() const noexcept { return m_active_count; }
+        bool is_active(std::uint32_t dense_index) const noexcept { return dense_index < m_active_count; }
+
+        void deactivate(entity e) { if (auto i = index(e)) deactivate_at(i.value()); }
+        void activate(entity e)   { if (auto i = index(e)) activate_at(i.value()); }
+
+        // Index-taking forms mirror erase_at(): used by component_pool, which has already
+        // resolved the index and would otherwise pay for a redundant lookup.
+        void deactivate_at(std::uint32_t dense_index)
+        {
+            GAMECOE_ASSERT_LOG(dense_index < m_dense.size(), "sparse_set::deactivate_at(): index out of bounds");
+            if (dense_index >= m_active_count) return;   // already inactive
+            --m_active_count;
+            swap_dense(dense_index, m_active_count);     // m_active_count now names the old last-active slot
+        }
+
+        void activate_at(std::uint32_t dense_index)
+        {
+            GAMECOE_ASSERT_LOG(dense_index < m_dense.size(), "sparse_set::activate_at(): index out of bounds");
+            if (dense_index < m_active_count) return;    // already active
+            swap_dense(dense_index, m_active_count);     // m_active_count names the first inactive slot
+            ++m_active_count;
         }
 
         std::optional<std::uint32_t> index(entity e) const
@@ -134,7 +175,7 @@ namespace gamecoe
             return m_dense[index];
         }
 
-        void clear() { m_sparse.clear(); m_dense.clear(); }
+        void clear() { m_sparse.clear(); m_dense.clear(); m_active_count = 0; }
         std::size_t size() const noexcept { return m_dense.size(); }
         bool empty() const noexcept { return m_dense.empty(); }
 

--- a/src/gamecoe/entity/entities.cpp
+++ b/src/gamecoe/entity/entities.cpp
@@ -34,7 +34,7 @@ namespace gamecoe
         }
 
         entity e = entity::create(id, generation);
-        get_pool<components::transform>()->add(e);
+        get_pool<components::transform>()->add(e, true);
 
         return e;
     }
@@ -143,10 +143,10 @@ namespace gamecoe
         }
 
         remove_parent(child);
-        parent_pool->add(child, components::parent{ parent });
+        parent_pool->add(child, true, components::parent{ parent });
 
         if (children_pool->contains(parent)) children_pool->get(parent).handles.push_back(child);
-        else children_pool->add(parent, components::children{ { child } });
+        else children_pool->add(parent, true, components::children{ { child } });
     }
 
     void entities::remove_parent(entity child)

--- a/src/gamecoe/entity/entities.cpp
+++ b/src/gamecoe/entity/entities.cpp
@@ -73,7 +73,7 @@ namespace gamecoe
 
             if (!valid(current)) continue;
 
-            remove_parent(current);
+            unlink_parent(current);
 
             if (has_component<components::children>(current))
             {
@@ -114,10 +114,7 @@ namespace gamecoe
             return;
         }
         m_self_active[e.id()] = true;
-
-        bool parent_active = !has_component<components::parent>(e)
-            || is_active(get_pool<components::parent>()->get(e).handle);
-        set_active(e, parent_active);
+        set_active(e, compute_world_active(e));
     }
 
     void entities::deactivate(entity e)
@@ -134,19 +131,11 @@ namespace gamecoe
         set_active(e, false);
     }
 
-    // The worklist carries a per-node target instead of one flat value: a self-inactive
-    // descendant must stay inactive even while an active ancestor above it reactivates.
+    // Each node carries its own target: a self-inactive descendant stays inactive even when
+    // an ancestor above it reactivates.
     void entities::set_active(entity e, bool world_active)
     {
-        if (is_active(e) == world_active) return;
-
-        for (auto &pool : m_pools) if (pool) (world_active ? pool->activate(e) : pool->deactivate(e));
-
-        if (!has_component<components::children>(e)) return;
-
-        std::vector<std::pair<entity, bool>> worklist;
-        for (entity child : get_pool<components::children>()->get(e).handles)
-            worklist.emplace_back(child, m_self_active[child.id()] && world_active);
+        std::vector<std::pair<entity, bool>> worklist{ { e, world_active } };
 
         while (!worklist.empty())
         {
@@ -158,18 +147,24 @@ namespace gamecoe
             for (auto &pool : m_pools) if (pool) (target ? pool->activate(current) : pool->deactivate(current));
 
             if (has_component<components::children>(current))
-                for (entity grandchild : get_pool<components::children>()->get(current).handles)
-                    worklist.emplace_back(grandchild, m_self_active[grandchild.id()] && target);
+                for (entity child : get_pool<components::children>()->get(current).handles)
+                    worklist.emplace_back(child, m_self_active[child.id()] && target);
         }
     }
 
-    // No storage of its own - this IS the active/inactive partition boundary the mandatory
-    // transform pool holds, so it stays consistent with every pool by construction.
+    bool entities::compute_world_active(entity e)
+    {
+        if (!m_self_active[e.id()]) return false;
+        return !has_component<components::parent>(e) || is_active(get_pool<components::parent>()->get(e).handle);
+    }
+
+    // Reads the transform pool's partition boundary directly - transform is mandatory, so
+    // is_active() can never disagree with the pools.
     bool entities::is_active(entity e) const
     {
         GAMECOE_ASSERT_LOG(valid(e), "entities::is_active(): entity is not valid");
-        auto pool = const_cast<entities*>(this)->get_pool<components::transform>();
-        GAMECOE_ASSERT_LOG(pool->contains(e), "entities::is_active(): transform missing (should be impossible - mandatory component)");
+        auto pool = find_pool<components::transform>();
+        GAMECOE_ASSERT_LOG(pool != nullptr && pool->contains(e), "entities::is_active(): transform missing (should be impossible - mandatory component)");
         return pool->is_active(e);
     }
 
@@ -222,7 +217,7 @@ namespace gamecoe
         if (children_pool->contains(parent)) children_pool->get(parent).handles.push_back(child);
         else children_pool->add(parent, is_active(parent), components::children{ { child } });
 
-        set_active(child, m_self_active[child.id()] && is_active(parent));
+        set_active(child, compute_world_active(child));
     }
 
     void entities::unlink_parent(entity child)
@@ -246,15 +241,23 @@ namespace gamecoe
 
     void entities::remove_parent(entity child)
     {
-        if (!has_component<components::parent>(child)) return;
+        if (!has_component<components::parent>(child))
+        {
+            logcoe::debug("entities::remove_parent(): entity has no parent, ignoring");
+            return;
+        }
 
         unlink_parent(child);
-        set_active(child, m_self_active[child.id()]);
+        set_active(child, compute_world_active(child));
     }
 
     void entities::remove_children(entity parent)
     {
-        if (!has_component<components::children>(parent)) return;
+        if (!has_component<components::children>(parent))
+        {
+            logcoe::debug("entities::remove_children(): entity has no children, ignoring");
+            return;
+        }
 
         auto children_pool = get_pool<components::children>();
         // Copied, not a reference: set_active() below can touch children_pool's own storage
@@ -266,7 +269,7 @@ namespace gamecoe
             if (has_component<components::parent>(child))
             {
                 get_pool<components::parent>()->remove(child);
-                set_active(child, m_self_active[child.id()]);
+                set_active(child, compute_world_active(child));
             }
         }
 

--- a/src/gamecoe/entity/entities.cpp
+++ b/src/gamecoe/entity/entities.cpp
@@ -75,11 +75,8 @@ namespace gamecoe
 
             unlink_parent(current);
 
-            if (has_component<components::children>(current))
-            {
-                const auto& handles = get_pool<components::children>()->get(current).handles;
-                to_destroy.insert(to_destroy.end(), handles.begin(), handles.end());
-            }
+            if (auto* kids = get_pool<components::children>()->try_get(current))
+                to_destroy.insert(to_destroy.end(), kids->handles.begin(), kids->handles.end());
 
             m_generations[current.id()]++;
             m_recycle_ids.push_back(current.id());
@@ -146,8 +143,8 @@ namespace gamecoe
 
             for (auto &pool : m_pools) if (pool) (target ? pool->activate(current) : pool->deactivate(current));
 
-            if (has_component<components::children>(current))
-                for (entity child : get_pool<components::children>()->get(current).handles)
+            if (auto* kids = get_pool<components::children>()->try_get(current))
+                for (entity child : kids->handles)
                     worklist.emplace_back(child, m_self_active[child.id()] && target);
         }
     }
@@ -155,7 +152,8 @@ namespace gamecoe
     bool entities::compute_world_active(entity e)
     {
         if (!m_self_active[e.id()]) return false;
-        return !has_component<components::parent>(e) || is_active(get_pool<components::parent>()->get(e).handle);
+        auto* p = get_pool<components::parent>()->try_get(e);
+        return !p || is_active(p->handle);
     }
 
     // Reads the transform pool's partition boundary directly - transform is mandatory, so
@@ -163,8 +161,12 @@ namespace gamecoe
     bool entities::is_active(entity e) const
     {
         GAMECOE_ASSERT_LOG(valid(e), "entities::is_active(): entity is not valid");
+        if (!valid(e)) return false;   // release-mode only - debug already caught it via the assert above
+
         auto pool = find_pool<components::transform>();
         GAMECOE_ASSERT_LOG(pool != nullptr && pool->contains(e), "entities::is_active(): transform missing (should be impossible - mandatory component)");
+        if (!pool || !pool->contains(e)) return false;   // release-mode only - debug already caught it via the assert above
+
         return pool->is_active(e);
     }
 
@@ -220,49 +222,50 @@ namespace gamecoe
         set_active(child, compute_world_active(child));
     }
 
-    void entities::unlink_parent(entity child)
+    bool entities::unlink_parent(entity child)
     {
-        if (!has_component<components::parent>(child)) return;
-
         auto parent_pool = get_pool<components::parent>();
-        entity old_parent = parent_pool->get(child).handle;
+        auto* parent_comp = parent_pool->try_get(child);
+        if (!parent_comp) return false;
 
-        if (has_component<components::children>(old_parent))
+        entity old_parent = parent_comp->handle;
+
+        auto children_pool = get_pool<components::children>();
+        if (auto* kids = children_pool->try_get(old_parent))
         {
-            auto children_pool = get_pool<components::children>();
-            std::erase(children_pool->get(old_parent).handles, child);
+            std::erase(kids->handles, child);
             // A childless entity has no children component at all, not one with an empty list -
-            // so has_component<children>(e) alone tells you whether an entity has any children.
-            if (!children_pool->get(old_parent).has_children()) children_pool->remove(old_parent);
+            // so has_children() alone tells you whether an entity has any children.
+            if (!kids->has_children()) children_pool->remove(old_parent);
         }
 
         parent_pool->remove(child);
+        return true;
     }
 
     void entities::remove_parent(entity child)
     {
-        if (!has_component<components::parent>(child))
+        if (!unlink_parent(child))
         {
             logcoe::debug("entities::remove_parent(): entity has no parent, ignoring");
             return;
         }
 
-        unlink_parent(child);
         set_active(child, compute_world_active(child));
     }
 
     void entities::remove_children(entity parent)
     {
-        if (!has_component<components::children>(parent))
+        auto children_pool = get_pool<components::children>();
+        auto* kids = children_pool->try_get(parent);
+        if (!kids)
         {
             logcoe::debug("entities::remove_children(): entity has no children, ignoring");
             return;
         }
 
-        auto children_pool = get_pool<components::children>();
-        // Copied, not a reference: set_active() below can touch children_pool's own storage
-        // (if a child has grandchildren), which would otherwise invalidate a reference into it.
-        std::vector<entity> handles = children_pool->get(parent).handles;
+        // Copy protects iteration against set_active() swapping storage within children_pool
+        std::vector<entity> handles = kids->handles;
 
         for (entity child : handles)
         {

--- a/src/gamecoe/entity/entities.cpp
+++ b/src/gamecoe/entity/entities.cpp
@@ -25,12 +25,14 @@ namespace gamecoe
             m_current_entity_id++;
             generation = 0;
             m_generations.push_back(generation);
+            m_self_active.push_back(true);
         }
         else
         {
             id = m_recycle_ids.back();
             m_recycle_ids.pop_back();
             generation = m_generations[id];
+            m_self_active[id] = true;
         }
 
         entity e = entity::create(id, generation);
@@ -91,6 +93,7 @@ namespace gamecoe
         m_pools.clear();
         m_recycle_ids.clear();
         m_generations.clear();
+        m_self_active.clear();
         m_current_entity_id = 0;
         logcoe::info("entities::clear(): cleared all entities");
     }
@@ -100,10 +103,81 @@ namespace gamecoe
         return e.id() < m_generations.size() && m_generations[e.id()] == e.generation();
     }
 
+    void entities::activate(entity e)
+    {
+        GAMECOE_ASSERT_LOG(valid(e), "entities::activate(): entity is not valid");
+        if (!valid(e)) return;
+
+        if (m_self_active[e.id()])
+        {
+            logcoe::debug("entities::activate(): entity already active, ignoring");
+            return;
+        }
+        m_self_active[e.id()] = true;
+
+        bool parent_active = !has_component<components::parent>(e)
+            || is_active(get_pool<components::parent>()->get(e).handle);
+        set_active(e, parent_active);
+    }
+
+    void entities::deactivate(entity e)
+    {
+        GAMECOE_ASSERT_LOG(valid(e), "entities::deactivate(): entity is not valid");
+        if (!valid(e)) return;
+
+        if (!m_self_active[e.id()])
+        {
+            logcoe::debug("entities::deactivate(): entity already inactive, ignoring");
+            return;
+        }
+        m_self_active[e.id()] = false;
+        set_active(e, false);
+    }
+
+    // The worklist carries a per-node target instead of one flat value: a self-inactive
+    // descendant must stay inactive even while an active ancestor above it reactivates.
+    void entities::set_active(entity e, bool world_active)
+    {
+        if (is_active(e) == world_active) return;
+
+        for (auto &pool : m_pools) if (pool) (world_active ? pool->activate(e) : pool->deactivate(e));
+
+        if (!has_component<components::children>(e)) return;
+
+        std::vector<std::pair<entity, bool>> worklist;
+        for (entity child : get_pool<components::children>()->get(e).handles)
+            worklist.emplace_back(child, m_self_active[child.id()] && world_active);
+
+        while (!worklist.empty())
+        {
+            auto [current, target] = worklist.back();
+            worklist.pop_back();
+
+            if (!valid(current) || is_active(current) == target) continue;
+
+            for (auto &pool : m_pools) if (pool) (target ? pool->activate(current) : pool->deactivate(current));
+
+            if (has_component<components::children>(current))
+                for (entity grandchild : get_pool<components::children>()->get(current).handles)
+                    worklist.emplace_back(grandchild, m_self_active[grandchild.id()] && target);
+        }
+    }
+
+    // No storage of its own - this IS the active/inactive partition boundary the mandatory
+    // transform pool holds, so it stays consistent with every pool by construction.
+    bool entities::is_active(entity e) const
+    {
+        GAMECOE_ASSERT_LOG(valid(e), "entities::is_active(): entity is not valid");
+        auto pool = const_cast<entities*>(this)->get_pool<components::transform>();
+        GAMECOE_ASSERT_LOG(pool->contains(e), "entities::is_active(): transform missing (should be impossible - mandatory component)");
+        return pool->is_active(e);
+    }
+
     void entities::reserve(std::size_t capacity)
     {
         m_generations.reserve(capacity);
         m_recycle_ids.reserve(capacity);
+        m_self_active.reserve(capacity);
 
         for (auto &pool : m_pools) if (pool) pool->reserve(capacity);
 
@@ -142,14 +216,16 @@ namespace gamecoe
             ++guard;
         }
 
-        remove_parent(child);
-        parent_pool->add(child, true, components::parent{ parent });
+        unlink_parent(child);
+        parent_pool->add(child, is_active(child), components::parent{ parent });
 
         if (children_pool->contains(parent)) children_pool->get(parent).handles.push_back(child);
-        else children_pool->add(parent, true, components::children{ { child } });
+        else children_pool->add(parent, is_active(parent), components::children{ { child } });
+
+        set_active(child, m_self_active[child.id()] && is_active(parent));
     }
 
-    void entities::remove_parent(entity child)
+    void entities::unlink_parent(entity child)
     {
         if (!has_component<components::parent>(child)) return;
 
@@ -168,15 +244,31 @@ namespace gamecoe
         parent_pool->remove(child);
     }
 
+    void entities::remove_parent(entity child)
+    {
+        if (!has_component<components::parent>(child)) return;
+
+        unlink_parent(child);
+        set_active(child, m_self_active[child.id()]);
+    }
+
     void entities::remove_children(entity parent)
     {
         if (!has_component<components::children>(parent)) return;
 
         auto children_pool = get_pool<components::children>();
-        const auto& handles = children_pool->get(parent).handles;
+        // Copied, not a reference: set_active() below can touch children_pool's own storage
+        // (if a child has grandchildren), which would otherwise invalidate a reference into it.
+        std::vector<entity> handles = children_pool->get(parent).handles;
 
         for (entity child : handles)
-            if (has_component<components::parent>(child)) get_pool<components::parent>()->remove(child);
+        {
+            if (has_component<components::parent>(child))
+            {
+                get_pool<components::parent>()->remove(child);
+                set_active(child, m_self_active[child.id()]);
+            }
+        }
 
         children_pool->remove(parent);
     }

--- a/tests/entity/component_pool_tests.cpp
+++ b/tests/entity/component_pool_tests.cpp
@@ -96,7 +96,7 @@ TEST_F(ComponentPoolTests, AddAndGetOperations)
     {
         auto e = entity::create(42, 0);
 
-        Position &pos = pool.add(e, Position{1.0f, 2.0f, 3.0f});
+        Position &pos = pool.add(e, true, Position{1.0f, 2.0f, 3.0f});
 
         EXPECT_TRUE(pool.contains(e));
         EXPECT_EQ(pool.size(), 1);
@@ -117,7 +117,7 @@ TEST_F(ComponentPoolTests, AddAndGetOperations)
         {
             auto e = entity::create(i, 0);
             entities.push_back(e);
-            pool.add(e, Position{static_cast<float>(i), 0.0f, 0.0f});
+            pool.add(e, true, Position{static_cast<float>(i), 0.0f, 0.0f});
         }
 
         EXPECT_EQ(pool.size(), 50);
@@ -137,9 +137,9 @@ TEST_F(ComponentPoolTests, RemoveSwapAndPop)
     auto e2 = entity::create(20, 0);
     auto e3 = entity::create(30, 0);
 
-    pool.add(e1, Position{1.0f, 0.0f, 0.0f});
-    pool.add(e2, Position{2.0f, 0.0f, 0.0f});
-    pool.add(e3, Position{3.0f, 0.0f, 0.0f});
+    pool.add(e1, true, Position{1.0f, 0.0f, 0.0f});
+    pool.add(e2, true, Position{2.0f, 0.0f, 0.0f});
+    pool.add(e3, true, Position{3.0f, 0.0f, 0.0f});
 
     pool.remove(e2);
 
@@ -160,7 +160,7 @@ TEST_F(ComponentPoolTests, GetConst)
 {
     auto e = entity::create(42, 0);
 
-    pool.add(e, Position{1.0f, 2.0f, 3.0f});
+    pool.add(e, true, Position{1.0f, 2.0f, 3.0f});
 
     const auto &const_pool = pool;
     const Position &comp = const_pool.get(e);
@@ -181,7 +181,7 @@ TEST_F(ComponentPoolTests, ForEachIteration)
     {
         auto e = entity::create(i, 0);
         entities.push_back(e);
-        pool.add(e, Position{static_cast<float>(i), 0.0f, 0.0f});
+        pool.add(e, true, Position{static_cast<float>(i), 0.0f, 0.0f});
     }
 
     int count = 0;
@@ -205,7 +205,7 @@ TEST_F(ComponentPoolTests, PerfectForwarding)
     auto e = entity::create(42, 0);
 
     MoveOnlyComponent comp(123);
-    move_pool.add(e, std::move(comp));
+    move_pool.add(e, true, std::move(comp));
 
     EXPECT_TRUE(move_pool.contains(e));
     EXPECT_EQ(*move_pool.get(e).data, 123);
@@ -224,9 +224,9 @@ TEST_F(ComponentPoolTests, ComponentLifecycle)
     auto e2 = entity::create(2, 0);
     auto e3 = entity::create(3, 0);
 
-    trackers.add(e1, LifetimeTracker{&counter});
-    trackers.add(e2, LifetimeTracker{&counter});
-    trackers.add(e3, LifetimeTracker{&counter});
+    trackers.add(e1, true, LifetimeTracker{&counter});
+    trackers.add(e2, true, LifetimeTracker{&counter});
+    trackers.add(e3, true, LifetimeTracker{&counter});
 
     EXPECT_EQ(counter, 3);
 
@@ -244,7 +244,7 @@ TEST_F(ComponentPoolTests, ComponentLifecycle)
 TEST_F(ComponentPoolTests, ClearPool)
 {
     for (std::uint32_t i = 0; i < 20; ++i)
-        pool.add(entity::create(i, 0), Position{0.0f, 0.0f, 0.0f});
+        pool.add(entity::create(i, 0), true, Position{0.0f, 0.0f, 0.0f});
 
     EXPECT_EQ(pool.size(), 20);
 

--- a/tests/entity/component_pool_tests.cpp
+++ b/tests/entity/component_pool_tests.cpp
@@ -342,6 +342,35 @@ TEST_F(ComponentPoolTests, AddIntoPoolWithInactiveEntities)
         EXPECT_TRUE(pool.is_active(a));
         EXPECT_FALSE(pool.is_active(d));
     }
+
+    // Test 3: add() a new entity directly as inactive into a pool with BOTH active and
+    // inactive entries already present
+    {
+        pool.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto e = entity::create(5, 0);
+
+        Position pos_a{1.0f, 0.0f, 0.0f};
+        Position pos_b{2.0f, 0.0f, 0.0f};
+        Position pos_e{5.0f, 0.0f, 0.0f};
+
+        pool.add(a, true, pos_a);
+        pool.add(b, true, pos_b);
+        pool.deactivate(b); // active=[a], inactive=[b]
+        ASSERT_EQ(pool.active_size(), 1);
+
+        Position &ref_e = pool.add(e, false, pos_e);
+
+        EXPECT_EQ(ref_e, pos_e);
+        EXPECT_EQ(pool.get(e), pos_e);
+        EXPECT_EQ(pool.get(a), pos_a); // untouched by the insert
+        EXPECT_EQ(pool.get(b), pos_b); // untouched by the insert
+        EXPECT_EQ(pool.active_size(), 1); // unchanged by the new inactive insert
+        EXPECT_TRUE(pool.is_active(a));
+        EXPECT_FALSE(pool.is_active(b));
+        EXPECT_FALSE(pool.is_active(e));
+    }
 }
 
 //==============================================================================

--- a/tests/entity/component_pool_tests.cpp
+++ b/tests/entity/component_pool_tests.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <gamecoe/entity/component_pool.hpp>
+#include <algorithm>
 #include <memory>
+#include <vector>
 
 using namespace gamecoe;
 
@@ -153,6 +155,360 @@ TEST_F(ComponentPoolTests, RemoveSwapAndPop)
 }
 
 //==============================================================================
+//                        Active/Inactive Partition
+//==============================================================================
+
+TEST_F(ComponentPoolTests, ActivePartition)
+{
+    std::vector<entity> entities;
+    std::vector<Position> values;
+
+    // Sweep: every entity still in the pool must still hold its originally-inserted value.
+    // This is the real regression guard - active_size()/is_active() can look correct while
+    // swap_components() silently desyncs a payload from its entity.
+    auto payload_sweep = [&]()
+    {
+        for (std::size_t i = 0; i < entities.size(); ++i)
+            if (pool.contains(entities[i]))
+                EXPECT_EQ(pool.get(entities[i]), values[i]);
+    };
+
+    // Test 1: fresh inserts are all active
+    {
+        for (std::uint32_t i = 0; i < 3; ++i)
+        {
+            auto e = entity::create(i, 0);
+            Position p{static_cast<float>(i), 0.0f, 0.0f};
+            entities.push_back(e);
+            values.push_back(p);
+            pool.add(e, true, p);
+        }
+
+        EXPECT_EQ(pool.active_size(), pool.size());
+        for (auto e : entities)
+            EXPECT_TRUE(pool.is_active(e));
+        payload_sweep();
+    }
+
+    auto e1 = entities[0];
+    auto e2 = entities[1];
+    auto e3 = entities[2];
+
+    // Test 2: deactivate(e) decrements active_size(), keeps contains() true, payloads stay paired
+    {
+        pool.deactivate(e2);
+        EXPECT_EQ(pool.active_size(), 2);
+        EXPECT_TRUE(pool.contains(e2));
+        EXPECT_FALSE(pool.is_active(e2));
+        payload_sweep();
+    }
+
+    // Test 3: deactivate(e) again on an already-inactive entity is a no-op
+    {
+        auto active_before = pool.active_size();
+        pool.deactivate(e2);
+        EXPECT_EQ(pool.active_size(), active_before);
+        payload_sweep();
+    }
+
+    // Test 4: activate(e) restores it to the active partition
+    {
+        pool.activate(e2);
+        EXPECT_TRUE(pool.is_active(e2));
+        EXPECT_EQ(pool.active_size(), 3);
+        payload_sweep();
+    }
+
+    // Test 5: activate(e) again on an already-active entity is a no-op
+    {
+        auto active_before = pool.active_size();
+        pool.activate(e2);
+        EXPECT_EQ(pool.active_size(), active_before);
+        payload_sweep();
+    }
+
+    // Test 6: deactivating every entity drops active_size() to 0, size() unchanged, all still contained
+    {
+        pool.deactivate(e1);
+        pool.deactivate(e2);
+        pool.deactivate(e3);
+
+        EXPECT_EQ(pool.active_size(), 0);
+        EXPECT_EQ(pool.size(), 3);
+        EXPECT_TRUE(pool.contains(e1));
+        EXPECT_TRUE(pool.contains(e2));
+        EXPECT_TRUE(pool.contains(e3));
+        payload_sweep();
+    }
+
+    // Test 7: multi-entity scenario - deactivate a subset, then activate a different subset,
+    // sweeping payload pairing after every single mutation
+    {
+        pool.clear();
+        entities.clear();
+        values.clear();
+
+        for (std::uint32_t i = 0; i < 6; ++i)
+        {
+            auto e = entity::create(i, 0);
+            Position p{static_cast<float>(i) * 10.0f, 1.0f, 2.0f};
+            entities.push_back(e);
+            values.push_back(p);
+            pool.add(e, true, p);
+        }
+        payload_sweep();
+
+        // Deactivate entities 1, 3, 5
+        pool.deactivate(entities[1]);
+        payload_sweep();
+        pool.deactivate(entities[3]);
+        payload_sweep();
+        pool.deactivate(entities[5]);
+        payload_sweep();
+
+        EXPECT_EQ(pool.active_size(), 3);
+        EXPECT_TRUE(pool.is_active(entities[0]));
+        EXPECT_FALSE(pool.is_active(entities[1]));
+        EXPECT_TRUE(pool.is_active(entities[2]));
+        EXPECT_FALSE(pool.is_active(entities[3]));
+        EXPECT_TRUE(pool.is_active(entities[4]));
+        EXPECT_FALSE(pool.is_active(entities[5]));
+
+        // Activate a different subset (1 and 3), leaving 5 inactive
+        pool.activate(entities[1]);
+        payload_sweep();
+        pool.activate(entities[3]);
+        payload_sweep();
+
+        EXPECT_EQ(pool.active_size(), 5);
+        EXPECT_TRUE(pool.is_active(entities[0]));
+        EXPECT_TRUE(pool.is_active(entities[1]));
+        EXPECT_TRUE(pool.is_active(entities[2]));
+        EXPECT_TRUE(pool.is_active(entities[3]));
+        EXPECT_TRUE(pool.is_active(entities[4]));
+        EXPECT_FALSE(pool.is_active(entities[5]));
+    }
+}
+
+//==============================================================================
+//                        Add Into a Pool With Inactive Entities
+//==============================================================================
+
+TEST_F(ComponentPoolTests, AddIntoPoolWithInactiveEntities)
+{
+    // Test 1: add() into a pool with [active ‖ inactive] must land the new component in its
+    // own slot without corrupting the existing inactive entity's payload - a naive
+    // `return m_components.back()` implementation would return a stale/wrong reference here.
+    {
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+
+        Position pos_a{1.0f, 0.0f, 0.0f};
+        Position pos_b{2.0f, 0.0f, 0.0f};
+        Position pos_c{3.0f, 0.0f, 0.0f};
+
+        pool.add(a, true, pos_a);
+        pool.add(b, true, pos_b);
+        pool.deactivate(b); // active=[a], inactive=[b]
+        ASSERT_TRUE(pool.is_active(a));
+        ASSERT_FALSE(pool.is_active(b));
+
+        Position &ref_c = pool.add(c, true, pos_c);
+
+        EXPECT_EQ(ref_c, pos_c);
+        EXPECT_EQ(pool.get(c), pos_c);
+        EXPECT_EQ(pool.get(b), pos_b); // untouched by the insert
+        EXPECT_EQ(pool.active_size(), 2);
+        EXPECT_TRUE(pool.is_active(c));
+        EXPECT_FALSE(pool.is_active(b));
+    }
+
+    // Test 2: add() a new entity directly as inactive into a pool that already has active entities
+    {
+        pool.clear();
+        auto a = entity::create(1, 0);
+        auto d = entity::create(4, 0);
+
+        Position pos_a{1.0f, 0.0f, 0.0f};
+        Position pos_d{4.0f, 0.0f, 0.0f};
+
+        pool.add(a, true, pos_a);
+        Position &ref_d = pool.add(d, false, pos_d);
+
+        EXPECT_EQ(ref_d, pos_d);
+        EXPECT_EQ(pool.get(d), pos_d);
+        EXPECT_EQ(pool.active_size(), 1);
+        EXPECT_TRUE(pool.is_active(a));
+        EXPECT_FALSE(pool.is_active(d));
+    }
+}
+
+//==============================================================================
+//                        Remove Across Active Boundary
+//==============================================================================
+
+TEST_F(ComponentPoolTests, RemoveAcrossActiveBoundary)
+{
+    // Test 1: remove an active entity that is NOT the last active one (mid), from a mixed pool
+    {
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+        auto d = entity::create(4, 0);
+
+        Position pos_a{1.0f, 0.0f, 0.0f}, pos_b{2.0f, 0.0f, 0.0f}, pos_c{3.0f, 0.0f, 0.0f}, pos_d{4.0f, 0.0f, 0.0f};
+
+        pool.add(a, true, pos_a);
+        pool.add(b, true, pos_b);
+        pool.add(c, true, pos_c);
+        pool.add(d, true, pos_d);
+        pool.deactivate(d); // active=[a,b,c], inactive=[d]
+
+        pool.remove(b); // b is active, not the last active entity (c is)
+
+        EXPECT_EQ(pool.active_size(), 2);
+        EXPECT_FALSE(pool.contains(b));
+        EXPECT_EQ(pool.get(a), pos_a);
+        EXPECT_EQ(pool.get(c), pos_c);
+        EXPECT_EQ(pool.get(d), pos_d);
+        EXPECT_TRUE(pool.is_active(a));
+        EXPECT_TRUE(pool.is_active(c));
+        EXPECT_FALSE(pool.is_active(d));
+    }
+
+    // Test 2: remove an inactive entity from a mixed pool
+    {
+        pool.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+
+        Position pos_a{1.0f, 0.0f, 0.0f}, pos_b{2.0f, 0.0f, 0.0f}, pos_c{3.0f, 0.0f, 0.0f};
+
+        pool.add(a, true, pos_a);
+        pool.add(b, true, pos_b);
+        pool.add(c, true, pos_c);
+        pool.deactivate(c); // active=[a,b], inactive=[c]
+
+        pool.remove(c);
+
+        EXPECT_EQ(pool.active_size(), 2);
+        EXPECT_EQ(pool.size(), 2);
+        EXPECT_FALSE(pool.contains(c));
+        EXPECT_EQ(pool.get(a), pos_a);
+        EXPECT_EQ(pool.get(b), pos_b);
+        EXPECT_TRUE(pool.is_active(a));
+        EXPECT_TRUE(pool.is_active(b));
+    }
+
+    // Test 3: remove the entity that IS the last active one - the self-move-guard case
+    // (`if (i != last_active) ...`) must not corrupt anything when the guard skips the move
+    {
+        pool.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+        auto d = entity::create(4, 0);
+
+        Position pos_a{1.0f, 0.0f, 0.0f}, pos_b{2.0f, 0.0f, 0.0f}, pos_c{3.0f, 0.0f, 0.0f}, pos_d{4.0f, 0.0f, 0.0f};
+
+        pool.add(a, true, pos_a);
+        pool.add(b, true, pos_b);
+        pool.add(c, true, pos_c);
+        pool.add(d, true, pos_d);
+        pool.deactivate(d); // active=[a,b,c], inactive=[d]
+
+        pool.remove(c); // c is the last active entity
+
+        EXPECT_EQ(pool.active_size(), 2);
+        EXPECT_FALSE(pool.contains(c));
+        EXPECT_EQ(pool.get(a), pos_a);
+        EXPECT_EQ(pool.get(b), pos_b);
+        EXPECT_EQ(pool.get(d), pos_d);
+        EXPECT_TRUE(pool.is_active(a));
+        EXPECT_TRUE(pool.is_active(b));
+        EXPECT_FALSE(pool.is_active(d));
+    }
+
+    // Tests 4-6: repeat the same three cases on a move-only component type, to exercise the
+    // move/swap code paths (swap_components()/std::move) on a non-trivial type
+    component_pool<MoveOnlyComponent> move_pool;
+
+    // Test 4: remove an active entity (mid) from a mixed pool - move-only
+    {
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+        auto d = entity::create(4, 0);
+
+        move_pool.add(a, true, MoveOnlyComponent(1));
+        move_pool.add(b, true, MoveOnlyComponent(2));
+        move_pool.add(c, true, MoveOnlyComponent(3));
+        move_pool.add(d, true, MoveOnlyComponent(4));
+        move_pool.deactivate(d);
+
+        move_pool.remove(b);
+
+        EXPECT_EQ(move_pool.active_size(), 2);
+        EXPECT_FALSE(move_pool.contains(b));
+        EXPECT_EQ(*move_pool.get(a).data, 1);
+        EXPECT_EQ(*move_pool.get(c).data, 3);
+        EXPECT_EQ(*move_pool.get(d).data, 4);
+        EXPECT_TRUE(move_pool.is_active(a));
+        EXPECT_TRUE(move_pool.is_active(c));
+        EXPECT_FALSE(move_pool.is_active(d));
+    }
+
+    // Test 5: remove an inactive entity from a mixed pool - move-only
+    {
+        move_pool.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+
+        move_pool.add(a, true, MoveOnlyComponent(1));
+        move_pool.add(b, true, MoveOnlyComponent(2));
+        move_pool.add(c, true, MoveOnlyComponent(3));
+        move_pool.deactivate(c);
+
+        move_pool.remove(c);
+
+        EXPECT_EQ(move_pool.active_size(), 2);
+        EXPECT_EQ(move_pool.size(), 2);
+        EXPECT_FALSE(move_pool.contains(c));
+        EXPECT_EQ(*move_pool.get(a).data, 1);
+        EXPECT_EQ(*move_pool.get(b).data, 2);
+    }
+
+    // Test 6: remove the last active entity - move-only, exercises the self-move guard
+    {
+        move_pool.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+        auto d = entity::create(4, 0);
+
+        move_pool.add(a, true, MoveOnlyComponent(1));
+        move_pool.add(b, true, MoveOnlyComponent(2));
+        move_pool.add(c, true, MoveOnlyComponent(3));
+        move_pool.add(d, true, MoveOnlyComponent(4));
+        move_pool.deactivate(d);
+
+        move_pool.remove(c);
+
+        EXPECT_EQ(move_pool.active_size(), 2);
+        EXPECT_FALSE(move_pool.contains(c));
+        EXPECT_EQ(*move_pool.get(a).data, 1);
+        EXPECT_EQ(*move_pool.get(b).data, 2);
+        EXPECT_EQ(*move_pool.get(d).data, 4);
+        EXPECT_TRUE(move_pool.is_active(a));
+        EXPECT_TRUE(move_pool.is_active(b));
+        EXPECT_FALSE(move_pool.is_active(d));
+    }
+}
+
+//==============================================================================
 //                        Const Access
 //==============================================================================
 
@@ -193,6 +549,81 @@ TEST_F(ComponentPoolTests, ForEachIteration)
     });
 
     EXPECT_EQ(count, 10);
+}
+
+//==============================================================================
+//                        For Each All (Full Scan Across Partitions)
+//==============================================================================
+
+TEST_F(ComponentPoolTests, ForEachAll)
+{
+    std::vector<entity> entities;
+
+    for (std::uint32_t i = 0; i < 6; ++i)
+    {
+        auto e = entity::create(i, 0);
+        entities.push_back(e);
+        pool.add(e, true, Position{static_cast<float>(i), 0.0f, 0.0f});
+    }
+
+    // Deactivate a subset
+    pool.deactivate(entities[1]);
+    pool.deactivate(entities[4]);
+
+    std::vector<entity> expected_active;
+    for (auto e : entities)
+        if (pool.is_active(e))
+            expected_active.push_back(e);
+    std::sort(expected_active.begin(), expected_active.end());
+
+    std::vector<entity> expected_all = entities;
+    std::sort(expected_all.begin(), expected_all.end());
+
+    // Test 1: mutable for_each() visits exactly the active partition
+    {
+        std::vector<entity> visited;
+        pool.for_each([&visited](entity e, Position &)
+        {
+            visited.push_back(e);
+        });
+        std::sort(visited.begin(), visited.end());
+        EXPECT_EQ(visited, expected_active);
+    }
+
+    // Test 2: mutable for_each_all() visits every entity, active and inactive
+    {
+        std::vector<entity> visited;
+        pool.for_each_all([&visited](entity e, Position &)
+        {
+            visited.push_back(e);
+        });
+        std::sort(visited.begin(), visited.end());
+        EXPECT_EQ(visited, expected_all);
+    }
+
+    const component_pool<Position> &const_pool = pool;
+
+    // Test 3: const for_each() visits exactly the active partition
+    {
+        std::vector<entity> visited;
+        const_pool.for_each([&visited](entity e, const Position &)
+        {
+            visited.push_back(e);
+        });
+        std::sort(visited.begin(), visited.end());
+        EXPECT_EQ(visited, expected_active);
+    }
+
+    // Test 4: const for_each_all() visits every entity, active and inactive
+    {
+        std::vector<entity> visited;
+        const_pool.for_each_all([&visited](entity e, const Position &)
+        {
+            visited.push_back(e);
+        });
+        std::sort(visited.begin(), visited.end());
+        EXPECT_EQ(visited, expected_all);
+    }
 }
 
 //==============================================================================

--- a/tests/entity/entities_tests.cpp
+++ b/tests/entity/entities_tests.cpp
@@ -2,7 +2,10 @@
 #include <gamecoe/entity/entities.hpp>
 #include <gamecoe/component/transform.hpp>
 #include <gamecoe/component/parent_child.hpp>
+#include <gamecoe/component/scene_tag.hpp>
 #include <chrono>
+#include <vector>
+#include <algorithm>
 #include "../test_utils.hpp"
 
 using namespace gamecoe;
@@ -585,5 +588,508 @@ TEST_F(EntitiesTests, DestroyCascade)
 
         // root's children component should no longer exist - middle was root's only child
         EXPECT_FALSE(mgr.has_component<components::children>(root));
+    }
+}
+
+//==============================================================================
+//                        Destroy vs. Active/Inactive Partition
+//==============================================================================
+
+TEST_F(EntitiesTests, DestroyKeepsActivePartitionIntact)
+{
+    // Test 1: destroying an ACTIVE entity leaves the active/inactive partition consistent
+    // across every pool - survivors' active-state and payloads are untouched by the swap-and-pop
+    {
+        mgr.clear();
+        std::vector<entity> es;
+        for (int i = 0; i < 6; ++i)
+        {
+            entity e = mgr.create();
+            mgr.add_component<Position>(e, Position{static_cast<float>(i), 0.0f, 0.0f});
+            mgr.add_component<Velocity>(e, Velocity{static_cast<float>(i) * 0.1f, 0.0f, 0.0f});
+            es.push_back(e);
+        }
+
+        mgr.deactivate(es[1]);
+        mgr.deactivate(es[3]);
+
+        entity destroyed = es[0]; // still active
+        mgr.destroy(destroyed);
+
+        EXPECT_FALSE(mgr.valid(destroyed));
+
+        std::vector<entity> active_found;
+        for (auto [e, pos, vel] : mgr.extract<Position, Velocity>())
+            active_found.push_back(e);
+
+        EXPECT_EQ(active_found.size(), 3u); // es[2], es[4], es[5]
+        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[2]) != active_found.end());
+        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[4]) != active_found.end());
+        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[5]) != active_found.end());
+
+        EXPECT_FALSE(mgr.is_active(es[1]));
+        EXPECT_TRUE(mgr.is_active(es[2]));
+        EXPECT_FALSE(mgr.is_active(es[3]));
+        EXPECT_TRUE(mgr.is_active(es[4]));
+        EXPECT_TRUE(mgr.is_active(es[5]));
+
+        for (int i = 1; i < 6; ++i)
+        {
+            Position *pos = mgr.get_component<Position>(es[i]);
+            Velocity *vel = mgr.get_component<Velocity>(es[i]);
+            ASSERT_NE(pos, nullptr);
+            ASSERT_NE(vel, nullptr);
+            EXPECT_EQ(pos->x, static_cast<float>(i));
+            EXPECT_EQ(vel->dx, static_cast<float>(i) * 0.1f);
+        }
+    }
+
+    // Test 2: destroying an INACTIVE entity doesn't change the active survivor count, and
+    // everyone else's active-state/payload stays intact
+    {
+        mgr.clear();
+        std::vector<entity> es;
+        for (int i = 0; i < 6; ++i)
+        {
+            entity e = mgr.create();
+            mgr.add_component<Position>(e, Position{static_cast<float>(i), 0.0f, 0.0f});
+            mgr.add_component<Velocity>(e, Velocity{static_cast<float>(i) * 0.1f, 0.0f, 0.0f});
+            es.push_back(e);
+        }
+
+        mgr.deactivate(es[1]);
+        mgr.deactivate(es[3]);
+
+        entity destroyed = es[1]; // inactive
+        mgr.destroy(destroyed);
+
+        EXPECT_FALSE(mgr.valid(destroyed));
+
+        std::vector<entity> active_found;
+        for (auto [e, pos, vel] : mgr.extract<Position, Velocity>())
+            active_found.push_back(e);
+
+        // Active survivor count unchanged from before the destroy: es[0], es[2], es[4], es[5]
+        EXPECT_EQ(active_found.size(), 4u);
+        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[0]) != active_found.end());
+        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[2]) != active_found.end());
+        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[4]) != active_found.end());
+        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[5]) != active_found.end());
+
+        EXPECT_TRUE(mgr.is_active(es[0]));
+        EXPECT_TRUE(mgr.is_active(es[2]));
+        EXPECT_FALSE(mgr.is_active(es[3]));
+        EXPECT_TRUE(mgr.is_active(es[4]));
+        EXPECT_TRUE(mgr.is_active(es[5]));
+
+        for (int i : { 0, 2, 3, 4, 5 })
+        {
+            Position *pos = mgr.get_component<Position>(es[i]);
+            Velocity *vel = mgr.get_component<Velocity>(es[i]);
+            ASSERT_NE(pos, nullptr);
+            ASSERT_NE(vel, nullptr);
+            EXPECT_EQ(pos->x, static_cast<float>(i));
+            EXPECT_EQ(vel->dx, static_cast<float>(i) * 0.1f);
+        }
+    }
+
+    // Test 3: destroying a parent with mixed active/inactive children exercises the cascade
+    // worklist against the partition-aware erase; entities outside the destroyed subtree
+    // are not silently deactivated or corrupted
+    {
+        mgr.clear();
+
+        entity other_active = mgr.create();
+        mgr.add_component<Position>(other_active, Position{10.0f, 0.0f, 0.0f});
+
+        entity other_inactive = mgr.create();
+        mgr.add_component<Position>(other_inactive, Position{20.0f, 0.0f, 0.0f});
+        mgr.deactivate(other_inactive);
+
+        entity parent = mgr.create();
+        mgr.add_component<Position>(parent, Position{30.0f, 0.0f, 0.0f});
+
+        entity child_active = mgr.create();
+        mgr.add_component<Position>(child_active, Position{31.0f, 0.0f, 0.0f});
+        mgr.set_parent(child_active, parent);
+
+        entity child_inactive = mgr.create();
+        mgr.add_component<Position>(child_inactive, Position{32.0f, 0.0f, 0.0f});
+        mgr.set_parent(child_inactive, parent);
+        mgr.deactivate(child_inactive);
+
+        mgr.destroy(parent);
+
+        EXPECT_FALSE(mgr.valid(parent));
+        EXPECT_FALSE(mgr.valid(child_active));
+        EXPECT_FALSE(mgr.valid(child_inactive));
+
+        // Entities outside the destroyed subtree keep their own active-state and payload
+        EXPECT_TRUE(mgr.valid(other_active));
+        EXPECT_TRUE(mgr.valid(other_inactive));
+        EXPECT_TRUE(mgr.is_active(other_active));
+        EXPECT_FALSE(mgr.is_active(other_inactive));
+        EXPECT_EQ(mgr.get_component<Position>(other_active)->x, 10.0f);
+        EXPECT_EQ(mgr.get_component<Position>(other_inactive)->x, 20.0f);
+
+        std::vector<entity> active_found;
+        for (auto [e, pos] : mgr.extract<Position>())
+            active_found.push_back(e);
+
+        EXPECT_EQ(active_found.size(), 1u); // only other_active survives in the active partition
+        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), other_active) != active_found.end());
+    }
+}
+
+//==============================================================================
+//                        Activate / Deactivate
+//==============================================================================
+
+TEST_F(EntitiesTests, ActivateDeactivate)
+{
+    entity e = mgr.create();
+    mgr.add_component<Position>(e, Position{1.0f, 2.0f, 3.0f});
+    mgr.add_component<Velocity>(e, Velocity{0.1f, 0.2f, 0.3f});
+
+    // Test 1: deactivate() removes the entity from extract<>() iteration but leaves its
+    // components in place, still reachable via has_component()/get_component()
+    {
+        mgr.deactivate(e);
+
+        bool found = false;
+        for (auto [ent, pos, vel] : mgr.extract<Position, Velocity>())
+            if (ent == e) found = true;
+        EXPECT_FALSE(found);
+
+        EXPECT_TRUE(mgr.has_component<Position>(e));
+        EXPECT_TRUE(mgr.has_component<Velocity>(e));
+        ASSERT_NE(mgr.get_component<Position>(e), nullptr);
+        ASSERT_NE(mgr.get_component<Velocity>(e), nullptr);
+        EXPECT_EQ(mgr.get_component<Position>(e)->x, 1.0f);
+        EXPECT_EQ(mgr.get_component<Velocity>(e)->dx, 0.1f);
+    }
+
+    // Test 2: activate() on the same entity restores it to extract<>() iteration, payload intact
+    {
+        mgr.activate(e);
+
+        bool found = false;
+        for (auto [ent, pos, vel] : mgr.extract<Position, Velocity>())
+            if (ent == e) found = true;
+        EXPECT_TRUE(found);
+
+        EXPECT_EQ(mgr.get_component<Position>(e)->x, 1.0f);
+        EXPECT_EQ(mgr.get_component<Velocity>(e)->dx, 0.1f);
+    }
+
+    // Test 3: a fresh entity is active by default at create(); is_active() tracks state at
+    // each transition, not just the final state
+    {
+        mgr.clear();
+        entity fresh = mgr.create();
+
+        EXPECT_TRUE(mgr.is_active(fresh));
+
+        mgr.deactivate(fresh);
+        EXPECT_FALSE(mgr.is_active(fresh));
+
+        mgr.activate(fresh);
+        EXPECT_TRUE(mgr.is_active(fresh));
+    }
+}
+
+//==============================================================================
+//                        Self-Active vs. World-Active Cascade
+//==============================================================================
+
+TEST_F(EntitiesTests, SelfActiveCascade)
+{
+    // Test 1: weapon-slot regression - reactivating a parent must restore each descendant to
+    // its OWN self_active state, not force every descendant active
+    {
+        mgr.clear();
+        entity player = mgr.create();
+        entity gun = mgr.create();
+        entity dagger = mgr.create();
+        entity stick = mgr.create();
+        mgr.set_parent(gun, player);
+        mgr.set_parent(dagger, player);
+        mgr.set_parent(stick, player);
+
+        // Only dagger/stick are explicitly deactivated - this touches only their own
+        // self_active, gun's self_active stays true
+        mgr.deactivate(dagger);
+        mgr.deactivate(stick);
+
+        EXPECT_TRUE(mgr.is_active(gun));
+        EXPECT_FALSE(mgr.is_active(dagger));
+        EXPECT_FALSE(mgr.is_active(stick));
+
+        // Deactivating the shared ancestor forces every descendant's world_active false,
+        // regardless of their own self_active
+        mgr.deactivate(player);
+
+        EXPECT_FALSE(mgr.is_active(gun));
+        EXPECT_FALSE(mgr.is_active(dagger));
+        EXPECT_FALSE(mgr.is_active(stick));
+
+        mgr.activate(player);
+
+        // Regression guard: reactivating player must NOT force dagger/stick active too -
+        // each descendant is restored to its own self_active state
+        EXPECT_TRUE(mgr.is_active(gun));
+        EXPECT_FALSE(mgr.is_active(dagger));
+        EXPECT_FALSE(mgr.is_active(stick));
+    }
+
+    // Test 2: deactivate() cascades to every one of the entity's pools, not just some
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        mgr.add_component<Position>(e, Position{1.0f, 2.0f, 3.0f});
+        mgr.add_component<Velocity>(e, Velocity{0.1f, 0.2f, 0.3f});
+        mgr.add_component<components::scene_tag>(e, components::scene_tag{});
+
+        mgr.deactivate(e);
+
+        EXPECT_FALSE(mgr.is_active(e));
+
+        bool found_position = false;
+        for (auto [ent, pos] : mgr.extract<Position>())
+            if (ent == e) found_position = true;
+        EXPECT_FALSE(found_position);
+
+        bool found_velocity = false;
+        for (auto [ent, vel] : mgr.extract<Velocity>())
+            if (ent == e) found_velocity = true;
+        EXPECT_FALSE(found_velocity);
+
+        bool found_scene_tag = false;
+        for (auto [ent, tag] : mgr.extract<components::scene_tag>())
+            if (ent == e) found_scene_tag = true;
+        EXPECT_FALSE(found_scene_tag);
+    }
+
+    // Test 3: multi-level chain - a self-inactive intermediate/leaf node stays inactive through
+    // an ancestor's deactivate()/activate() cycle, at depth 2 (not just direct children)
+    {
+        mgr.clear();
+        entity player = mgr.create();
+        entity backpack = mgr.create();
+        entity potion = mgr.create();
+        mgr.set_parent(backpack, player);
+        mgr.set_parent(potion, backpack);
+
+        // Only potion is explicitly deactivated - backpack's self_active stays true (default)
+        mgr.deactivate(potion);
+
+        mgr.deactivate(player);
+        EXPECT_FALSE(mgr.is_active(backpack));
+        EXPECT_FALSE(mgr.is_active(potion));
+
+        mgr.activate(player);
+
+        // backpack's self_active was never touched, so it comes back active with player
+        EXPECT_TRUE(mgr.is_active(backpack));
+        // potion's own self_active is still false - stays inactive through the whole cycle
+        EXPECT_FALSE(mgr.is_active(potion));
+    }
+
+    // Test 4: activate() on an already self-active entity is a no-op - no crash, no corruption
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        mgr.add_component<Position>(e, Position{4.0f, 5.0f, 6.0f});
+
+        EXPECT_TRUE(mgr.is_active(e));
+
+        mgr.activate(e); // already self-active - should be ignored
+
+        EXPECT_TRUE(mgr.is_active(e));
+
+        bool found = false;
+        for (auto [ent, pos] : mgr.extract<Position>())
+            if (ent == e) found = true;
+        EXPECT_TRUE(found);
+        EXPECT_EQ(mgr.get_component<Position>(e)->x, 4.0f);
+    }
+}
+
+//==============================================================================
+//                        Reparent Recomputes World-Active
+//==============================================================================
+
+TEST_F(EntitiesTests, ReparentRecomputesWorldActive)
+{
+    // Test 1: set_parent onto an inactive parent forces the child inactive purely from the
+    // ancestor-chain change - child's own self_active is never touched. Re-parenting again onto
+    // an active parent restores it, again with no explicit activate()/deactivate() call on the
+    // child anywhere in this block
+    {
+        mgr.clear();
+        entity child = mgr.create();
+        EXPECT_TRUE(mgr.is_active(child));
+
+        entity inactive_parent = mgr.create();
+        mgr.deactivate(inactive_parent);
+
+        mgr.set_parent(child, inactive_parent);
+        EXPECT_FALSE(mgr.is_active(child));
+
+        entity active_parent = mgr.create();
+        mgr.set_parent(child, active_parent);
+        EXPECT_TRUE(mgr.is_active(child));
+    }
+
+    // Test 2: remove_parent from an inactive parent restores world_active from the child's own
+    // self_active alone, now that it's a parentless root - no explicit activate() call
+    {
+        mgr.clear();
+        entity parent = mgr.create();
+        mgr.deactivate(parent);
+
+        entity child = mgr.create();
+        mgr.set_parent(child, parent);
+        // child's own self_active is still true (never explicitly deactivated), but the
+        // inactive parent suppresses it
+        EXPECT_FALSE(mgr.is_active(child));
+
+        mgr.remove_parent(child);
+        EXPECT_TRUE(mgr.is_active(child));
+    }
+
+    // Test 3: remove_children recomputes each detached child independently from its own
+    // self_active, not a blanket reactivation of every former child
+    {
+        mgr.clear();
+        entity parent = mgr.create();
+        mgr.deactivate(parent);
+
+        entity child_a = mgr.create();
+        entity child_b = mgr.create();
+        mgr.set_parent(child_a, parent);
+        mgr.set_parent(child_b, parent);
+        mgr.deactivate(child_b); // child_b's own self_active is now false; child_a's stays true
+
+        // Setup check: parent's inactivity suppresses both, regardless of their own self_active
+        EXPECT_FALSE(mgr.is_active(child_a));
+        EXPECT_FALSE(mgr.is_active(child_b));
+
+        mgr.remove_children(parent);
+
+        EXPECT_TRUE(mgr.is_active(child_a));  // parentless root now - self_active alone decides
+        EXPECT_FALSE(mgr.is_active(child_b)); // still parentless, but its own self_active is false
+    }
+
+    // Test 4: reparenting between two inactive parents must never observably pass through an
+    // active intermediate state. set_parent() detaches the old link via the private
+    // unlink_parent() helper (not the public remove_parent()) specifically so the child is never
+    // treated as a parentless root mid-call - which, with its true self_active of true, would
+    // otherwise be momentarily active - before being linked to the new parent and recomputed once
+    // at the very end via a single set_active() call. This test can only observe before/after
+    // state, but that's still a meaningful regression guard: a broken implementation that routed
+    // through remove_parent()'s own recompute would flip is_active(child) to true right before
+    // set_parent() completes, and a caller inspecting state from a signal/callback triggered by
+    // that recompute would see it.
+    {
+        mgr.clear();
+        entity old_parent = mgr.create();
+        entity new_parent = mgr.create();
+        mgr.deactivate(old_parent);
+        mgr.deactivate(new_parent);
+
+        entity child = mgr.create();
+        mgr.set_parent(child, old_parent);
+        EXPECT_FALSE(mgr.is_active(child));
+
+        mgr.set_parent(child, new_parent);
+        EXPECT_FALSE(mgr.is_active(child));
+    }
+}
+
+//==============================================================================
+//                        Add Component To Inactive Entity
+//==============================================================================
+
+TEST_F(EntitiesTests, AddComponentToInactiveEntity)
+{
+    // Test 1: add_component() on an already-deactivated entity inserts the new component
+    // straight into the inactive partition - it's hidden from extract<>() until activate(),
+    // even though it was never itself explicitly deactivated. The reference returned by
+    // add_component() must stay valid immediately after the call (regression guard against the
+    // internal deactivate-on-insert swap relocating it before the caller reads from it).
+    {
+        mgr.clear();
+        entity e = mgr.create();
+        mgr.add_component<Position>(e, Position{1.0f, 2.0f, 3.0f});
+        mgr.deactivate(e);
+
+        Velocity &vel_ref = mgr.add_component<Velocity>(e, Velocity{4.0f, 5.0f, 6.0f});
+
+        // Reference is valid right away, not just via a fresh get_component() afterward
+        EXPECT_EQ(vel_ref.dx, 4.0f);
+        EXPECT_EQ(vel_ref.dy, 5.0f);
+        EXPECT_EQ(vel_ref.dz, 6.0f);
+
+        bool found_single = false;
+        for (auto [ent, vel] : mgr.extract<Velocity>())
+            if (ent == e) found_single = true;
+        EXPECT_FALSE(found_single);
+
+        bool found_multi = false;
+        for (auto [ent, pos, vel] : mgr.extract<Position, Velocity>())
+            if (ent == e) found_multi = true;
+        EXPECT_FALSE(found_multi);
+
+        // Direct lookup still works regardless of active state
+        Velocity *vel = mgr.get_component<Velocity>(e);
+        ASSERT_NE(vel, nullptr);
+        EXPECT_EQ(vel->dx, 4.0f);
+        EXPECT_EQ(vel->dy, 5.0f);
+        EXPECT_EQ(vel->dz, 6.0f);
+
+        mgr.activate(e);
+
+        bool found_single_active = false;
+        for (auto [ent, v] : mgr.extract<Velocity>())
+            if (ent == e) found_single_active = true;
+        EXPECT_TRUE(found_single_active);
+
+        bool found_multi_active = false;
+        for (auto [ent, pos, v] : mgr.extract<Position, Velocity>())
+        {
+            if (ent == e)
+            {
+                found_multi_active = true;
+                EXPECT_EQ(pos.x, 1.0f);
+                EXPECT_EQ(pos.y, 2.0f);
+                EXPECT_EQ(pos.z, 3.0f);
+                EXPECT_EQ(v.dx, 4.0f);
+                EXPECT_EQ(v.dy, 5.0f);
+                EXPECT_EQ(v.dz, 6.0f);
+            }
+        }
+        EXPECT_TRUE(found_multi_active);
+    }
+
+    // Test 2: set_parent() on an already-deactivated child propagates that same inactive state
+    // into its freshly-inserted parent component, instead of defaulting it to active
+    {
+        mgr.clear();
+        entity child = mgr.create();
+        mgr.deactivate(child);
+
+        entity parent = mgr.create();
+        mgr.set_parent(child, parent);
+
+        bool found = false;
+        for (auto [ent, p] : mgr.extract<components::parent>())
+            if (ent == child) found = true;
+        EXPECT_FALSE(found);
+
+        // Direct lookup unaffected by active state
+        EXPECT_TRUE(mgr.has_component<components::parent>(child));
+        ASSERT_NE(mgr.get_component<components::parent>(child), nullptr);
+        EXPECT_EQ(mgr.get_component<components::parent>(child)->handle, parent);
     }
 }

--- a/tests/entity/entities_tests.cpp
+++ b/tests/entity/entities_tests.cpp
@@ -476,6 +476,56 @@ TEST_F(EntitiesTests, Hierarchy)
 }
 
 //==============================================================================
+//                        RemoveChildren With Grandchildren (copy-before-iterate guard)
+//==============================================================================
+
+TEST_F(EntitiesTests, RemoveChildrenWithGrandchildren)
+{
+    // remove_children() copies parent's children handles before iterating, specifically because
+    // detaching one child can itself cascade set_active() into that child's own children -
+    // mutating storage the loop would otherwise still be reading from. Every other
+    // remove_children() test in this file uses flat children (no grandchildren), so none of them
+    // exercise that cascade; this is the one guard that would catch the copy being reverted to a
+    // reference.
+    mgr.clear();
+    entity parent = mgr.create();
+    entity child_a = mgr.create();
+    entity child_b = mgr.create();
+    entity grandchild = mgr.create();
+    mgr.set_parent(child_a, parent);
+    mgr.set_parent(child_b, parent);
+    mgr.set_parent(grandchild, child_a);
+
+    mgr.deactivate(parent);
+    mgr.deactivate(grandchild); // grandchild's own self_active is now false; child_a's stays true
+
+    // Setup check: parent's inactivity suppresses the whole subtree, including the grandchild
+    EXPECT_FALSE(mgr.is_active(child_a));
+    EXPECT_FALSE(mgr.is_active(child_b));
+    EXPECT_FALSE(mgr.is_active(grandchild));
+
+    mgr.remove_children(parent);
+
+    // Test 1: detaching child_a/child_b from parent leaves grandchild's own link untouched -
+    // it's still parented to child_a, not orphaned or reparented to parent
+    EXPECT_FALSE(mgr.has_component<components::children>(parent));
+    EXPECT_FALSE(mgr.has_component<components::parent>(child_a));
+    EXPECT_FALSE(mgr.has_component<components::parent>(child_b));
+    EXPECT_TRUE(mgr.valid(child_a));
+    EXPECT_TRUE(mgr.valid(child_b));
+    EXPECT_TRUE(mgr.valid(grandchild));
+    ASSERT_TRUE(mgr.has_component<components::parent>(grandchild));
+    EXPECT_EQ(mgr.get_component<components::parent>(grandchild)->handle, child_a);
+
+    // Test 2: each detached child's world_active recomputes from its own self_active as a new
+    // parentless root; grandchild's world_active recomputes relative to child_a's new state, not
+    // parent's old one, and still respects grandchild's own self_active independently
+    EXPECT_TRUE(mgr.is_active(child_a));   // parentless root now - self_active alone decides
+    EXPECT_TRUE(mgr.is_active(child_b));   // same
+    EXPECT_FALSE(mgr.is_active(grandchild)); // follows child_a (now active), but own self_active is false
+}
+
+//==============================================================================
 //                        SetParent Cycle Detection (debug-time assert)
 //==============================================================================
 
@@ -1091,5 +1141,78 @@ TEST_F(EntitiesTests, AddComponentToInactiveEntity)
         EXPECT_TRUE(mgr.has_component<components::parent>(child));
         ASSERT_NE(mgr.get_component<components::parent>(child), nullptr);
         EXPECT_EQ(mgr.get_component<components::parent>(child)->handle, parent);
+    }
+}
+
+//==============================================================================
+//                        Deep Hierarchy Cascade (iterative worklist, not recursion)
+//==============================================================================
+
+TEST_F(EntitiesTests, DeepHierarchyCascade)
+{
+    // destroy()/set_active() cascade a hierarchy via an explicit std::vector-backed worklist,
+    // deliberately not recursion, so a malformed/deep parent chain can't stack-overflow. Every
+    // other test in this file tops out at 2-3 levels deep, so a recursive rewrite of either
+    // cascade would pass the whole suite - this is the one guard deep enough to actually catch
+    // that regression. Chain is built leaf-first (each new entity becomes the parent of the
+    // previous one) so set_parent()'s own cycle-detection ancestor walk stays O(1) per call -
+    // the walk starts at the brand-new parent, which has no ancestors yet.
+    constexpr std::size_t DEPTH = 50000;
+
+    std::vector<entity> chain;
+    chain.reserve(DEPTH + 1);
+
+    entity leaf = mgr.create();
+    chain.push_back(leaf);
+    entity current = leaf;
+    for (std::size_t i = 0; i < DEPTH; ++i)
+    {
+        entity next = mgr.create();
+        mgr.set_parent(current, next);
+        chain.push_back(next);
+        current = next;
+    }
+
+    entity deepest = chain.front();
+    entity root = chain.back();
+
+    // Test 1: deactivate(root) cascades world_active = false all the way down to the deepest
+    // descendant, tens of thousands of levels away
+    {
+        mgr.deactivate(root);
+        EXPECT_FALSE(mgr.is_active(deepest));
+    }
+
+    // Test 2: activate(root) cascades world_active = true back down to the deepest descendant
+    {
+        mgr.activate(root);
+        EXPECT_TRUE(mgr.is_active(deepest));
+    }
+
+    // Test 3: a self-deactivated midpoint still suppresses everything below it (down to deepest)
+    // through a root-level deactivate()/activate() cycle, while everything between root and the
+    // midpoint - never touched itself - comes back active. Same self/world-split invariant as
+    // SelfActiveCascade, just exercised at depth instead of on a 2-3 node tree.
+    {
+        entity midpoint = chain[chain.size() / 2];
+        entity near_root = chain[chain.size() - 2]; // ancestor of midpoint, child of root
+
+        mgr.deactivate(midpoint); // self_active(midpoint) = false, doesn't touch anyone else
+
+        mgr.deactivate(root);
+        mgr.activate(root);
+
+        EXPECT_FALSE(mgr.is_active(midpoint)); // own self_active still false
+        EXPECT_FALSE(mgr.is_active(deepest));  // descendant of a world-inactive midpoint
+        EXPECT_TRUE(mgr.is_active(near_root)); // ancestor of midpoint, restored with root
+    }
+
+    // Test 4: destroy(root) cascades removal all the way down to the deepest descendant
+    {
+        mgr.destroy(root);
+
+        EXPECT_FALSE(mgr.valid(root));
+        EXPECT_FALSE(mgr.valid(deepest));
+        EXPECT_EQ(mgr.size(), 0u);
     }
 }

--- a/tests/entity/entities_tests.cpp
+++ b/tests/entity/entities_tests.cpp
@@ -623,9 +623,9 @@ TEST_F(EntitiesTests, DestroyKeepsActivePartitionIntact)
             active_found.push_back(e);
 
         EXPECT_EQ(active_found.size(), 3u); // es[2], es[4], es[5]
-        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[2]) != active_found.end());
-        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[4]) != active_found.end());
-        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[5]) != active_found.end());
+        EXPECT_TRUE(test_utils::has(active_found, es[2]));
+        EXPECT_TRUE(test_utils::has(active_found, es[4]));
+        EXPECT_TRUE(test_utils::has(active_found, es[5]));
 
         EXPECT_FALSE(mgr.is_active(es[1]));
         EXPECT_TRUE(mgr.is_active(es[2]));
@@ -671,10 +671,10 @@ TEST_F(EntitiesTests, DestroyKeepsActivePartitionIntact)
 
         // Active survivor count unchanged from before the destroy: es[0], es[2], es[4], es[5]
         EXPECT_EQ(active_found.size(), 4u);
-        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[0]) != active_found.end());
-        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[2]) != active_found.end());
-        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[4]) != active_found.end());
-        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), es[5]) != active_found.end());
+        EXPECT_TRUE(test_utils::has(active_found, es[0]));
+        EXPECT_TRUE(test_utils::has(active_found, es[2]));
+        EXPECT_TRUE(test_utils::has(active_found, es[4]));
+        EXPECT_TRUE(test_utils::has(active_found, es[5]));
 
         EXPECT_TRUE(mgr.is_active(es[0]));
         EXPECT_TRUE(mgr.is_active(es[2]));
@@ -737,7 +737,7 @@ TEST_F(EntitiesTests, DestroyKeepsActivePartitionIntact)
             active_found.push_back(e);
 
         EXPECT_EQ(active_found.size(), 1u); // only other_active survives in the active partition
-        EXPECT_TRUE(std::find(active_found.begin(), active_found.end(), other_active) != active_found.end());
+        EXPECT_TRUE(test_utils::has(active_found, other_active));
     }
 }
 
@@ -804,8 +804,8 @@ TEST_F(EntitiesTests, ActivateDeactivate)
 
 TEST_F(EntitiesTests, SelfActiveCascade)
 {
-    // Test 1: weapon-slot regression - reactivating a parent must restore each descendant to
-    // its OWN self_active state, not force every descendant active
+    // Test 1: reactivating a parent must restore each descendant to its OWN self_active
+    // state, not force every descendant active (independently-toggled siblings)
     {
         mgr.clear();
         entity player = mgr.create();

--- a/tests/entity/extraction_tests.cpp
+++ b/tests/entity/extraction_tests.cpp
@@ -232,6 +232,89 @@ TEST_F(ExtractionTests, EmptyAndEdgeCases)
 }
 
 //==============================================================================
+//                        Active Partition Bound
+//==============================================================================
+
+TEST_F(ExtractionTests, ActivePartitionBound)
+{
+    // Test 1: pool selection is driven by active_size(), not size() - construct two pools
+    // where the two metrics disagree on which pool is "smallest" and confirm extract<>()
+    // still returns the correct (small) result set.
+    //
+    // Transform pool: 100 total entities, only 1 stays active (99 deactivated).
+    // Health pool: 5 total entities, all 5 active.
+    // Old selection (by size()): Health (5) < Transform (100) -> Health chosen as primary.
+    // New selection (by active_size()): Transform (1) < Health (5) -> Transform chosen as primary.
+    // This makes old vs. new pool selection disagree; the matching entity below is the only
+    // one with both components, so a correct result here means the smallest ACTIVE partition
+    // was iterated correctly regardless of which pool ended up driving the loop.
+    {
+        entity match = mgr.create();
+        mgr.add_component<Transform>(match, Transform{1.0f, 2.0f, 3.0f});
+        mgr.add_component<Health>(match, Health{50});
+
+        for (int i = 0; i < 99; ++i)
+        {
+            entity e = mgr.create();
+            mgr.add_component<Transform>(e, Transform{static_cast<float>(i), 0.0f, 0.0f});
+            mgr.deactivate(e);
+        }
+
+        for (int i = 0; i < 4; ++i)
+        {
+            entity e = mgr.create();
+            mgr.add_component<Health>(e, Health{i});
+        }
+
+        auto extracted = mgr.extract<Transform, Health>();
+
+        std::vector<entity> found_entities;
+        for (auto [e, t, h] : extracted)
+        {
+            found_entities.push_back(e);
+            EXPECT_EQ(t.x, 1.0f);
+            EXPECT_EQ(t.y, 2.0f);
+            EXPECT_EQ(t.z, 3.0f);
+            EXPECT_EQ(h.value, 50);
+        }
+
+        EXPECT_EQ(found_entities.size(), 1);
+        EXPECT_EQ(found_entities[0], match);
+    }
+
+    // Test 2: a pool with active_size() == 0 (but size() > 0) makes the extraction empty,
+    // regardless of which pool is picked as primary. This is the case that actually breaks
+    // if active_size() weren't wired into the selection: the smallest-active-partition bound
+    // must be 0, so the driving loop must never execute.
+    {
+        mgr.clear();
+
+        for (int i = 0; i < 50; ++i)
+        {
+            entity e = mgr.create();
+            mgr.add_component<Transform>(e, Transform{static_cast<float>(i), 0.0f, 0.0f});
+            mgr.deactivate(e);
+        }
+
+        for (int i = 0; i < 3; ++i)
+        {
+            entity e = mgr.create();
+            mgr.add_component<Health>(e, Health{i});
+        }
+
+        auto extracted = mgr.extract<Transform, Health>();
+        EXPECT_EQ(extracted.begin(), extracted.end());
+
+        int count = 0;
+        for ([[maybe_unused]] auto [e, t, h] : extracted)
+        {
+            ++count;
+        }
+        EXPECT_EQ(count, 0);
+    }
+}
+
+//==============================================================================
 //                        Const Correctness
 //==============================================================================
 

--- a/tests/entity/extraction_tests.cpp
+++ b/tests/entity/extraction_tests.cpp
@@ -2,6 +2,7 @@
 #include <gamecoe/entity/entities.hpp>
 #include <vector>
 #include <algorithm>
+#include "../test_utils.hpp"
 
 using namespace gamecoe;
 
@@ -84,10 +85,10 @@ TEST_F(ExtractionTests, BasicExtractionAndFiltering)
         }
 
         EXPECT_EQ(found_entities.size(), 4); // e1, e3, e4, e5
-        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e1) != found_entities.end());
-        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e3) != found_entities.end());
-        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e4) != found_entities.end());
-        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e5) != found_entities.end());
+        EXPECT_TRUE(test_utils::has(found_entities, e1));
+        EXPECT_TRUE(test_utils::has(found_entities, e3));
+        EXPECT_TRUE(test_utils::has(found_entities, e4));
+        EXPECT_TRUE(test_utils::has(found_entities, e5));
     }
 
     // Test 2: Extract single component (Velocity)
@@ -101,9 +102,9 @@ TEST_F(ExtractionTests, BasicExtractionAndFiltering)
         }
 
         EXPECT_EQ(found_entities.size(), 3); // e2, e3, e4
-        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e2) != found_entities.end());
-        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e3) != found_entities.end());
-        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e4) != found_entities.end());
+        EXPECT_TRUE(test_utils::has(found_entities, e2));
+        EXPECT_TRUE(test_utils::has(found_entities, e3));
+        EXPECT_TRUE(test_utils::has(found_entities, e4));
     }
 
     // Test 3: Extract multiple components (Transform + Velocity)
@@ -120,8 +121,8 @@ TEST_F(ExtractionTests, BasicExtractionAndFiltering)
         }
 
         EXPECT_EQ(found_entities.size(), 2); // Only e3 and e4
-        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e3) != found_entities.end());
-        EXPECT_TRUE(std::find(found_entities.begin(), found_entities.end(), e4) != found_entities.end());
+        EXPECT_TRUE(test_utils::has(found_entities, e3));
+        EXPECT_TRUE(test_utils::has(found_entities, e4));
     }
 
     // Test 4: Verify component values can be read correctly
@@ -464,9 +465,9 @@ TEST_F(ExtractionTests, IteratorProtocol)
         }
 
         EXPECT_EQ(x_values.size(), 3);
-        EXPECT_TRUE(std::find(x_values.begin(), x_values.end(), 1.0f) != x_values.end());
-        EXPECT_TRUE(std::find(x_values.begin(), x_values.end(), 2.0f) != x_values.end());
-        EXPECT_TRUE(std::find(x_values.begin(), x_values.end(), 3.0f) != x_values.end());
+        EXPECT_TRUE(test_utils::has(x_values, 1.0f));
+        EXPECT_TRUE(test_utils::has(x_values, 2.0f));
+        EXPECT_TRUE(test_utils::has(x_values, 3.0f));
     }
 
     // Test 7: Manual iteration with begin/end

--- a/tests/entity/sparse_set_tests.cpp
+++ b/tests/entity/sparse_set_tests.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <gamecoe/entity/sparse_set.hpp>
+#include <algorithm>
 #include <vector>
 
 using namespace gamecoe;
@@ -178,6 +179,330 @@ TEST_F(SparseSetTests, EraseAtOperations)
 }
 
 //==============================================================================
+//                        Active/Inactive Partition
+//==============================================================================
+
+TEST_F(SparseSetTests, ActivePartition)
+{
+    // Test 1: fresh inserts are all active
+    {
+        std::vector<entity> entities;
+        for (std::uint32_t i = 0; i < 5; ++i)
+        {
+            auto e = entity::create(i, 0);
+            entities.push_back(e);
+            set.insert(e);
+        }
+
+        EXPECT_EQ(set.active_size(), set.size());
+        for (std::uint32_t i = 0; i < static_cast<std::uint32_t>(set.size()); ++i)
+            EXPECT_TRUE(set.is_active(i));
+    }
+
+    // Tests 2-5: deactivate/activate toggling on a single entity, including no-op repeats
+    set.clear();
+    auto e1 = entity::create(1, 0);
+    auto e2 = entity::create(2, 0);
+    auto e3 = entity::create(3, 0);
+    set.insert(e1);
+    set.insert(e2);
+    set.insert(e3);
+    auto original_active = set.active_size();
+
+    // Test 2: deactivate(e) decrements active_size(), keeps contains() true, moves index past the boundary
+    set.deactivate(e2);
+    EXPECT_EQ(set.active_size(), original_active - 1);
+    EXPECT_TRUE(set.contains(e2));
+    EXPECT_GE(set.index(e2).value(), set.active_size());
+
+    // Test 3: deactivate(e) again on an already-inactive entity is a no-op
+    {
+        auto active_before = set.active_size();
+        auto index_before = set.index(e2).value();
+        set.deactivate(e2);
+        EXPECT_EQ(set.active_size(), active_before);
+        EXPECT_EQ(set.index(e2).value(), index_before);
+    }
+
+    // Test 4: activate(e) restores it to the active partition
+    set.activate(e2);
+    EXPECT_LT(set.index(e2).value(), set.active_size());
+    EXPECT_EQ(set.active_size(), original_active);
+
+    // Test 5: activate(e) again on an already-active entity is a no-op
+    {
+        auto active_before = set.active_size();
+        auto index_before = set.index(e2).value();
+        set.activate(e2);
+        EXPECT_EQ(set.active_size(), active_before);
+        EXPECT_EQ(set.index(e2).value(), index_before);
+    }
+
+    // Test 6: deactivating every entity drops active_size() to 0, size() unchanged, all still contained
+    {
+        set.deactivate(e1);
+        set.deactivate(e2);
+        set.deactivate(e3);
+
+        EXPECT_EQ(set.active_size(), 0);
+        EXPECT_EQ(set.size(), 3);
+        EXPECT_TRUE(set.contains(e1));
+        EXPECT_TRUE(set.contains(e2));
+        EXPECT_TRUE(set.contains(e3));
+    }
+
+    // Test 7: partition sweep - deactivating a subset never loses or duplicates entities across [0, size())
+    {
+        set.clear();
+        std::vector<entity> inserted;
+        for (std::uint32_t i = 0; i < 5; ++i)
+        {
+            auto e = entity::create(i, 0);
+            inserted.push_back(e);
+            set.insert(e);
+        }
+
+        // Deactivate every other entity
+        std::vector<entity> expected_active;
+        std::vector<entity> expected_inactive;
+        for (std::size_t i = 0; i < inserted.size(); ++i)
+        {
+            if (i % 2 == 0)
+                expected_active.push_back(inserted[i]);
+            else
+            {
+                set.deactivate(inserted[i]);
+                expected_inactive.push_back(inserted[i]);
+            }
+        }
+
+        for (auto e : expected_active)
+            EXPECT_LT(set.index(e).value(), set.active_size());
+        for (auto e : expected_inactive)
+            EXPECT_GE(set.index(e).value(), set.active_size());
+
+        // No entity lost or duplicated across the full dense range
+        std::vector<entity> all_by_dense_index;
+        for (std::uint32_t i = 0; i < static_cast<std::uint32_t>(set.size()); ++i)
+            all_by_dense_index.push_back(set.get_entity_at_index(i));
+
+        std::sort(all_by_dense_index.begin(), all_by_dense_index.end());
+        std::vector<entity> sorted_inserted = inserted;
+        std::sort(sorted_inserted.begin(), sorted_inserted.end());
+        EXPECT_EQ(all_by_dense_index, sorted_inserted);
+    }
+}
+
+//==============================================================================
+//                        Erase Across Active Boundary
+//==============================================================================
+
+TEST_F(SparseSetTests, EraseAcrossActiveBoundary)
+{
+    // Test 1: erasing an active entity while another is inactive must route through the
+    // boundary first - regression guard for the swap-and-pop dropping an inactive entity
+    // into the active partition (or vice versa)
+    {
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+
+        set.insert(a);
+        set.insert(b);
+        set.insert(c);
+        set.deactivate(c); // active=[a,b], inactive=[c]
+        ASSERT_EQ(set.active_size(), 2);
+
+        set.erase(a);
+
+        // Pre-fix bug candidate: active_size() left at 2 with c incorrectly landing active
+        constexpr std::size_t buggy_active_size = 2;
+        EXPECT_NE(set.active_size(), buggy_active_size);
+        EXPECT_EQ(set.active_size(), 1);
+
+        EXPECT_TRUE(set.is_active(set.index(b).value()));
+        EXPECT_FALSE(set.is_active(set.index(c).value()));
+        EXPECT_TRUE(set.contains(b));
+        EXPECT_TRUE(set.contains(c));
+        EXPECT_FALSE(set.contains(a));
+    }
+
+    // Test 2: erase an active entity that is NOT the last active one (mid)
+    {
+        set.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+        auto d = entity::create(4, 0);
+
+        set.insert(a);
+        set.insert(b);
+        set.insert(c);
+        set.insert(d);
+        set.deactivate(d); // active=[a,b,c], inactive=[d]
+
+        set.erase(b); // b is active, not the last active entity (c is)
+
+        EXPECT_EQ(set.active_size(), 2);
+        EXPECT_FALSE(set.contains(b));
+        EXPECT_TRUE(set.contains(a));
+        EXPECT_TRUE(set.contains(c));
+        EXPECT_TRUE(set.contains(d));
+        EXPECT_TRUE(set.is_active(set.index(a).value()));
+        EXPECT_TRUE(set.is_active(set.index(c).value()));
+        EXPECT_FALSE(set.is_active(set.index(d).value()));
+    }
+
+    // Test 3: erase the entity that IS the last active one
+    {
+        set.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+        auto d = entity::create(4, 0);
+
+        set.insert(a);
+        set.insert(b);
+        set.insert(c);
+        set.insert(d);
+        set.deactivate(d); // active=[a,b,c], inactive=[d]
+
+        set.erase(c); // c is the last active entity
+
+        EXPECT_EQ(set.active_size(), 2);
+        EXPECT_FALSE(set.contains(c));
+        EXPECT_TRUE(set.contains(a));
+        EXPECT_TRUE(set.contains(b));
+        EXPECT_TRUE(set.contains(d));
+        EXPECT_TRUE(set.is_active(set.index(a).value()));
+        EXPECT_TRUE(set.is_active(set.index(b).value()));
+        EXPECT_FALSE(set.is_active(set.index(d).value()));
+    }
+
+    // Test 4: erase an inactive entity that is NOT the dense-back element
+    {
+        set.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+        auto d = entity::create(4, 0);
+        auto e = entity::create(5, 0);
+
+        set.insert(a);
+        set.insert(b);
+        set.insert(c);
+        set.insert(d);
+        set.insert(e);
+        set.deactivate(c);
+        set.deactivate(d); // active=[a,b,e], inactive=[d,c] with d NOT at the dense-back position
+
+        ASSERT_FALSE(set.is_active(set.index(d).value()));
+        ASSERT_NE(set.index(d).value(), static_cast<std::uint32_t>(set.size() - 1)); // d is not the dense-back element
+
+        set.erase(d);
+
+        EXPECT_EQ(set.active_size(), 3);
+        EXPECT_FALSE(set.contains(d));
+        EXPECT_TRUE(set.contains(a));
+        EXPECT_TRUE(set.contains(b));
+        EXPECT_TRUE(set.contains(c));
+        EXPECT_TRUE(set.contains(e));
+        EXPECT_FALSE(set.is_active(set.index(c).value()));
+    }
+
+    // Test 5: erase an inactive entity that IS the dense-back element
+    {
+        set.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+
+        set.insert(a);
+        set.insert(b);
+        set.insert(c);
+        set.deactivate(c); // active=[a,b], inactive=[c], c is the dense-back element
+
+        ASSERT_EQ(set.index(c).value(), static_cast<std::uint32_t>(set.size() - 1));
+
+        set.erase(c);
+
+        EXPECT_EQ(set.active_size(), 2);
+        EXPECT_EQ(set.size(), 2);
+        EXPECT_TRUE(set.contains(a));
+        EXPECT_TRUE(set.contains(b));
+        EXPECT_FALSE(set.contains(c));
+    }
+
+    // Test 6: erase the only entity in the set (when it's active)
+    {
+        set.clear();
+        auto a = entity::create(1, 0);
+        set.insert(a);
+
+        set.erase(a);
+
+        EXPECT_EQ(set.size(), 0);
+        EXPECT_EQ(set.active_size(), 0);
+        EXPECT_TRUE(set.empty());
+        EXPECT_FALSE(set.contains(a));
+    }
+
+    // Test 7: erase-all in mixed active/inactive order ends in size() == 0 && active_size() == 0
+    {
+        set.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+        auto d = entity::create(4, 0);
+
+        set.insert(a);
+        set.insert(b);
+        set.insert(c);
+        set.insert(d);
+        set.deactivate(b);
+        set.deactivate(d); // active=[a,c], inactive contains b and d
+
+        set.erase(d); // inactive
+        set.erase(a); // active
+        set.erase(c); // active
+        set.erase(b); // inactive
+
+        EXPECT_EQ(set.size(), 0);
+        EXPECT_EQ(set.active_size(), 0);
+        EXPECT_TRUE(set.empty());
+        EXPECT_FALSE(set.contains(a));
+        EXPECT_FALSE(set.contains(b));
+        EXPECT_FALSE(set.contains(c));
+        EXPECT_FALSE(set.contains(d));
+    }
+
+    // Test 8: entirely-active set (no inactive entities at all) - confirm erase still
+    // behaves exactly as before this ticket (regression check for the plain case)
+    {
+        set.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+
+        set.insert(a);
+        set.insert(b);
+        set.insert(c);
+
+        set.erase(b); // mid element, everything active
+
+        EXPECT_EQ(set.size(), 2);
+        EXPECT_EQ(set.active_size(), 2);
+        EXPECT_TRUE(set.contains(a));
+        EXPECT_FALSE(set.contains(b));
+        EXPECT_TRUE(set.contains(c));
+        EXPECT_EQ(set.index(a).value(), 0);
+        EXPECT_EQ(set.index(c).value(), 1);
+        EXPECT_TRUE(set.is_active(set.index(a).value()));
+        EXPECT_TRUE(set.is_active(set.index(c).value()));
+    }
+}
+
+//==============================================================================
 //                        Generation Handling
 //==============================================================================
 
@@ -283,12 +608,16 @@ TEST_F(SparseSetTests, MoveSemantics)
 
     set1.insert(e1);
     set1.insert(e2);
+    set1.deactivate(e2);
     EXPECT_EQ(set1.size(), 2);
+    EXPECT_EQ(set1.active_size(), 1);
 
     // Move constructor
     sparse_set set2(std::move(set1));
     EXPECT_EQ(set2.size(), 2);
+    EXPECT_EQ(set2.active_size(), 1);
     EXPECT_EQ(set1.size(), 0);
+    EXPECT_EQ(set1.active_size(), 0);
     EXPECT_TRUE(set2.contains(e1));
     EXPECT_TRUE(set2.contains(e2));
 
@@ -296,6 +625,9 @@ TEST_F(SparseSetTests, MoveSemantics)
     sparse_set set3;
     set3 = std::move(set2);
     EXPECT_EQ(set3.size(), 2);
+    EXPECT_EQ(set3.active_size(), 1);
+    EXPECT_EQ(set2.size(), 0);
+    EXPECT_EQ(set2.active_size(), 0);
     EXPECT_TRUE(set3.contains(e1));
     EXPECT_TRUE(set3.contains(e2));
 }

--- a/tests/entity/sparse_set_tests.cpp
+++ b/tests/entity/sparse_set_tests.cpp
@@ -25,7 +25,7 @@ TEST_F(SparseSetTests, InsertOperations)
     {
         auto e = entity::create(42, 0);
 
-        set.insert(e);
+        set.insert(e, true);
 
         EXPECT_TRUE(set.contains(e));
         EXPECT_EQ(set.size(), 1);
@@ -46,7 +46,7 @@ TEST_F(SparseSetTests, InsertOperations)
             entities.push_back(entity::create(i, 0));
 
         for (auto e : entities)
-            set.insert(e);
+            set.insert(e, true);
 
         EXPECT_EQ(set.size(), 100);
 
@@ -60,11 +60,52 @@ TEST_F(SparseSetTests, InsertOperations)
         set.clear();
         auto e = entity::create(42, 0);
 
-        set.insert(e);
-        set.insert(e); // Duplicate insert
+        set.insert(e, true);
+        set.insert(e, true); // Duplicate insert
 
         EXPECT_EQ(set.size(), 1); // Size unchanged
         EXPECT_TRUE(set.contains(e));
+    }
+
+    // Test 4: Insert inactive entity into an empty set
+    {
+        set.clear();
+        auto e = entity::create(42, 0);
+
+        set.insert(e, false);
+
+        EXPECT_EQ(set.active_size(), 0);
+        EXPECT_FALSE(set.is_active(set.index(e).value()));
+        EXPECT_TRUE(set.contains(e));
+
+        auto index = set.index(e);
+        EXPECT_TRUE(index.has_value());
+    }
+
+    // Test 5: Insert inactive entity into a set with existing active AND inactive entries
+    {
+        set.clear();
+        auto a = entity::create(1, 0);
+        auto b = entity::create(2, 0);
+        auto c = entity::create(3, 0);
+        set.insert(a, true);
+        set.insert(b, true);
+        set.insert(c, true);
+        set.deactivate(b); // active=[a,c], inactive=[b]
+        ASSERT_EQ(set.active_size(), 2);
+
+        auto d = entity::create(4, 0);
+        set.insert(d, false);
+
+        EXPECT_EQ(set.active_size(), 2); // unchanged by the new inactive insert
+        EXPECT_EQ(set.size(), 4);
+        EXPECT_TRUE(set.contains(d));
+        EXPECT_FALSE(set.is_active(set.index(d).value()));
+
+        // Existing partition undisturbed
+        EXPECT_TRUE(set.is_active(set.index(a).value()));
+        EXPECT_TRUE(set.is_active(set.index(c).value()));
+        EXPECT_FALSE(set.is_active(set.index(b).value()));
     }
 }
 
@@ -78,7 +119,7 @@ TEST_F(SparseSetTests, EraseOperations)
     {
         auto e = entity::create(42, 0);
 
-        set.insert(e);
+        set.insert(e, true);
         set.erase(e);
 
         EXPECT_FALSE(set.contains(e));
@@ -96,9 +137,9 @@ TEST_F(SparseSetTests, EraseOperations)
         auto e2 = entity::create(20, 0);
         auto e3 = entity::create(30, 0);
 
-        set.insert(e1);
-        set.insert(e2);
-        set.insert(e3);
+        set.insert(e1, true);
+        set.insert(e2, true);
+        set.insert(e3, true);
 
         // Erase middle entity (e2)
         set.erase(e2);
@@ -119,7 +160,7 @@ TEST_F(SparseSetTests, EraseOperations)
         auto e1 = entity::create(10, 0);
         auto e2 = entity::create(20, 0);
 
-        set.insert(e1);
+        set.insert(e1, true);
         EXPECT_EQ(set.size(), 1);
 
         set.erase(e2); // e2 not in set
@@ -141,9 +182,9 @@ TEST_F(SparseSetTests, EraseAtOperations)
         auto e2 = entity::create(20, 0);
         auto e3 = entity::create(30, 0);
 
-        set.insert(e1);
-        set.insert(e2);
-        set.insert(e3);
+        set.insert(e1, true);
+        set.insert(e2, true);
+        set.insert(e3, true);
 
         // Erase middle entity by index (e2 is at dense index 1)
         set.erase_at(1);
@@ -169,7 +210,7 @@ TEST_F(SparseSetTests, EraseAtOperations)
     {
         set.clear();
         auto e = entity::create(42, 0);
-        set.insert(e);
+        set.insert(e, true);
 
         set.erase_at(5); // Out of bounds, should be no-op
 
@@ -191,7 +232,7 @@ TEST_F(SparseSetTests, ActivePartition)
         {
             auto e = entity::create(i, 0);
             entities.push_back(e);
-            set.insert(e);
+            set.insert(e, true);
         }
 
         EXPECT_EQ(set.active_size(), set.size());
@@ -204,9 +245,9 @@ TEST_F(SparseSetTests, ActivePartition)
     auto e1 = entity::create(1, 0);
     auto e2 = entity::create(2, 0);
     auto e3 = entity::create(3, 0);
-    set.insert(e1);
-    set.insert(e2);
-    set.insert(e3);
+    set.insert(e1, true);
+    set.insert(e2, true);
+    set.insert(e3, true);
     auto original_active = set.active_size();
 
     // Test 2: deactivate(e) decrements active_size(), keeps contains() true, moves index past the boundary
@@ -259,7 +300,7 @@ TEST_F(SparseSetTests, ActivePartition)
         {
             auto e = entity::create(i, 0);
             inserted.push_back(e);
-            set.insert(e);
+            set.insert(e, true);
         }
 
         // Deactivate every other entity
@@ -307,9 +348,9 @@ TEST_F(SparseSetTests, EraseAcrossActiveBoundary)
         auto b = entity::create(2, 0);
         auto c = entity::create(3, 0);
 
-        set.insert(a);
-        set.insert(b);
-        set.insert(c);
+        set.insert(a, true);
+        set.insert(b, true);
+        set.insert(c, true);
         set.deactivate(c); // active=[a,b], inactive=[c]
         ASSERT_EQ(set.active_size(), 2);
 
@@ -335,10 +376,10 @@ TEST_F(SparseSetTests, EraseAcrossActiveBoundary)
         auto c = entity::create(3, 0);
         auto d = entity::create(4, 0);
 
-        set.insert(a);
-        set.insert(b);
-        set.insert(c);
-        set.insert(d);
+        set.insert(a, true);
+        set.insert(b, true);
+        set.insert(c, true);
+        set.insert(d, true);
         set.deactivate(d); // active=[a,b,c], inactive=[d]
 
         set.erase(b); // b is active, not the last active entity (c is)
@@ -361,10 +402,10 @@ TEST_F(SparseSetTests, EraseAcrossActiveBoundary)
         auto c = entity::create(3, 0);
         auto d = entity::create(4, 0);
 
-        set.insert(a);
-        set.insert(b);
-        set.insert(c);
-        set.insert(d);
+        set.insert(a, true);
+        set.insert(b, true);
+        set.insert(c, true);
+        set.insert(d, true);
         set.deactivate(d); // active=[a,b,c], inactive=[d]
 
         set.erase(c); // c is the last active entity
@@ -388,11 +429,11 @@ TEST_F(SparseSetTests, EraseAcrossActiveBoundary)
         auto d = entity::create(4, 0);
         auto e = entity::create(5, 0);
 
-        set.insert(a);
-        set.insert(b);
-        set.insert(c);
-        set.insert(d);
-        set.insert(e);
+        set.insert(a, true);
+        set.insert(b, true);
+        set.insert(c, true);
+        set.insert(d, true);
+        set.insert(e, true);
         set.deactivate(c);
         set.deactivate(d); // active=[a,b,e], inactive=[d,c] with d NOT at the dense-back position
 
@@ -417,9 +458,9 @@ TEST_F(SparseSetTests, EraseAcrossActiveBoundary)
         auto b = entity::create(2, 0);
         auto c = entity::create(3, 0);
 
-        set.insert(a);
-        set.insert(b);
-        set.insert(c);
+        set.insert(a, true);
+        set.insert(b, true);
+        set.insert(c, true);
         set.deactivate(c); // active=[a,b], inactive=[c], c is the dense-back element
 
         ASSERT_EQ(set.index(c).value(), static_cast<std::uint32_t>(set.size() - 1));
@@ -437,7 +478,7 @@ TEST_F(SparseSetTests, EraseAcrossActiveBoundary)
     {
         set.clear();
         auto a = entity::create(1, 0);
-        set.insert(a);
+        set.insert(a, true);
 
         set.erase(a);
 
@@ -455,10 +496,10 @@ TEST_F(SparseSetTests, EraseAcrossActiveBoundary)
         auto c = entity::create(3, 0);
         auto d = entity::create(4, 0);
 
-        set.insert(a);
-        set.insert(b);
-        set.insert(c);
-        set.insert(d);
+        set.insert(a, true);
+        set.insert(b, true);
+        set.insert(c, true);
+        set.insert(d, true);
         set.deactivate(b);
         set.deactivate(d); // active=[a,c], inactive contains b and d
 
@@ -484,9 +525,9 @@ TEST_F(SparseSetTests, EraseAcrossActiveBoundary)
         auto b = entity::create(2, 0);
         auto c = entity::create(3, 0);
 
-        set.insert(a);
-        set.insert(b);
-        set.insert(c);
+        set.insert(a, true);
+        set.insert(b, true);
+        set.insert(c, true);
 
         set.erase(b); // mid element, everything active
 
@@ -512,7 +553,7 @@ TEST_F(SparseSetTests, GenerationMismatch)
     auto e_gen0 = entity::create(42, 0);
     auto e_gen1 = entity::create(42, 1);
 
-    set.insert(e_gen0);
+    set.insert(e_gen0, true);
 
     // e_gen0 is contained, but e_gen1 (same id, different gen) is NOT
     EXPECT_TRUE(set.contains(e_gen0));
@@ -535,10 +576,10 @@ TEST_F(SparseSetTests, PagingBehavior)
     auto e2048 = entity::create(2048, 0); // Page 2
     auto e5000 = entity::create(5000, 0); // Page 4
 
-    set.insert(e0);
-    set.insert(e1024);
-    set.insert(e2048);
-    set.insert(e5000);
+    set.insert(e0, true);
+    set.insert(e1024, true);
+    set.insert(e2048, true);
+    set.insert(e5000, true);
 
     EXPECT_EQ(set.size(), 4);
     EXPECT_TRUE(set.contains(e0));
@@ -554,7 +595,7 @@ TEST_F(SparseSetTests, PagingBehavior)
 TEST_F(SparseSetTests, ClearSet)
 {
     for (std::uint32_t i = 0; i < 50; ++i)
-        set.insert(entity::create(i, 0));
+        set.insert(entity::create(i, 0), true);
 
     EXPECT_EQ(set.size(), 50);
 
@@ -581,7 +622,7 @@ TEST_F(SparseSetTests, IterateDense)
     {
         auto e = entity::create(i * 10, 0); // IDs: 0, 10, 20, ..., 90
         entities.push_back(e);
-        set.insert(e);
+        set.insert(e, true);
     }
 
     // Iterate using begin()/end()
@@ -606,8 +647,8 @@ TEST_F(SparseSetTests, MoveSemantics)
     auto e1 = entity::create(10, 0);
     auto e2 = entity::create(20, 0);
 
-    set1.insert(e1);
-    set1.insert(e2);
+    set1.insert(e1, true);
+    set1.insert(e2, true);
     set1.deactivate(e2);
     EXPECT_EQ(set1.size(), 2);
     EXPECT_EQ(set1.active_size(), 1);
@@ -643,7 +684,7 @@ TEST_F(SparseSetTests, ReserveCapacity)
 
     // Insert 500 entities (should not trigger reallocation)
     for (std::uint32_t i = 0; i < 500; ++i)
-        set.insert(entity::create(i, 0));
+        set.insert(entity::create(i, 0), true);
 
     EXPECT_EQ(set.size(), 500);
 

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -6,6 +6,8 @@
 #include <gtest/gtest.h>
 #include <gamecoe/entity/entities.hpp>
 #include <gamecoe/component/transform.hpp>
+#include <vector>
+#include <algorithm>
 namespace test_utils
 {
     // Fatally asserts mgr has exactly one entity, then writes its handle to out (for tests that flush one spawn and need its real handle).
@@ -18,6 +20,12 @@ namespace test_utils
         {
             out = ent;
         });
+    }
+
+    template <typename T>
+    bool has(const std::vector<T> &values, const T &value)
+    {
+        return std::find(values.begin(), values.end(), value) != values.end();
     }
 
     inline void expect_vec3_near(const glm::vec3 &actual, const glm::vec3 &expected, float epsilon = 1e-5f)


### PR DESCRIPTION
This adds an active/inactive partition to sparse_set and component_pool so iteration can skip inactive entities for free, plus entities::activate()/deactivate() with a self/world active split so reactivating a parent restores each descendant to its own last state instead of forcing the whole subtree on.

- Add an active/inactive partition to sparse_set, mirrored into component_pool's component array
- Fix erase() to route through the active boundary first, so destroying an active entity can't corrupt the partition
- Add entities::activate()/deactivate()/is_active(), with a self/world active split so reactivating a parent restores each descendant to its own last state
- Cascade active-state changes through a hierarchy subtree, and recompute it whenever set_parent()/remove_parent()/remove_children() changes an entity's ancestor chain
- Make component inserts respect an entity's current active state instead of always inserting active
- Narrow iteration (extraction<>(), component_pool::for_each()) to the active partition, with for_each_all() added for a full scan
- Add try_get() as a single-lookup alternative to paired has_component()/get() calls
- Harden a few precondition checks with real early returns instead of relying on debug-only asserts
- Add tests across sparse_set, component_pool, entities, and extraction