### PR TITLE
[API]: Migrate error handling to std::expected

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -22,11 +22,12 @@ jobs:
             cmake-generator: 'Ninja'
             cmake-options: '-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DGAMECOE_USE_TESTCOE=ON -DGAMECOE_GLFW_WAYLAND=OFF'
 
-          # Linux with Clang
+          # Linux with Clang (libc++, not libstdc++ - libstdc++'s <expected> is incompatible with Clang)
           - name: "Linux Clang"
             compiler: clang
             cmake-generator: 'Ninja'
-            cmake-options: '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DGAMECOE_USE_TESTCOE=ON -DGAMECOE_GLFW_WAYLAND=OFF'
+            cmake-options: '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -DGAMECOE_USE_TESTCOE=ON -DGAMECOE_GLFW_WAYLAND=OFF'
+            extra-packages: 'libc++-dev libc++abi-dev'
 
     steps:
     - name: Checkout repository
@@ -37,7 +38,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build xorg-dev libgl1-mesa-dev libglu1-mesa-dev
+        sudo apt-get install -y ninja-build xorg-dev libgl1-mesa-dev libglu1-mesa-dev ${{ matrix.extra-packages }}
       shell: bash
 
     - name: Configure CMake

--- a/include/colorcoe.hpp
+++ b/include/colorcoe.hpp
@@ -2,7 +2,9 @@
 
 #include <cstdint>
 #include <string>
+#include <expected>
 #include <glm/glm.hpp>
+#include <gamecoe/utils/error.hpp>
 
 namespace gamecoe
 {
@@ -37,7 +39,7 @@ namespace gamecoe
         // Clamps values to [0.0f, 1.0f]
         static Color fromNormalized(float red, float green, float blue, float alpha = 1.0f);
         // Color::fromHex("#RRGGBBAA") or Color::fromHex("#RRGGBB")
-        static Color fromHex(const std::string &hex);
+        [[nodiscard]] static std::expected<Color, error> fromHex(const std::string &hex);
         // Lerps between Color a and Color b by t
         static Color lerp(const Color &a, const Color &b, float t);
     };

--- a/include/gamecoe/utils/error.hpp
+++ b/include/gamecoe/utils/error.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+namespace gamecoe
+{
+    enum class error_code
+    {
+        invalid_format,
+        opengl_error,
+        path_resolution_failed,
+        unsupported_platform
+    };
+
+    struct error
+    {
+        error_code code;
+        std::string message;
+    };
+} // namespace gamecoe

--- a/include/gamecoe/utils/error.hpp
+++ b/include/gamecoe/utils/error.hpp
@@ -6,7 +6,7 @@ namespace gamecoe
 {
     enum class error_code
     {
-        invalid_format,
+        invalid_argument,
         opengl_error,
         path_resolution_failed,
         unsupported_platform

--- a/include/gamecoe/utils/error_handler.hpp
+++ b/include/gamecoe/utils/error_handler.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <string>
-#include <stdexcept>
 #include <cassert>
+#include <expected>
 #include <gamecoe_config.hpp>
+#include <gamecoe/utils/error.hpp>
 
 #if GAMECOE_USE_LOGCOE
     #include <logcoe.hpp>
@@ -16,22 +17,18 @@ namespace gamecoe
 {
     namespace detail
     {
-        [[noreturn]] static inline void throwError(const std::string &message)
+        // Centralizes the "always log on error construction" behavior.
+        [[nodiscard]] error make_error(error_code code, const std::string &message);
+
+        [[nodiscard]] inline error invalid_argument(const std::string &message)
         {
-            logcoe::error(message);
-            throw std::runtime_error(message);
+            return make_error(error_code::invalid_argument, message);
         }
 
-        [[noreturn]] static inline void invalidArgument(const std::string &message)
-        {
-            logcoe::error(message);
-            throw std::invalid_argument(message);
-        }
-
-        // Checks for API error and throws if exists (currently only OpenGL supported)
-        void checkAndThrowError(const std::string &method);
+        // Checks for API error (currently only OpenGL supported)
+        [[nodiscard]] std::expected<void, error> check_error(const std::string &method);
 
         // Clears any existing API errors (currently only OpenGL supported)
-        void clearError();
+        void clear_error();
     } // namespace detail
 } // namespace gamecoe

--- a/include/gamecoe/utils/paths.hpp
+++ b/include/gamecoe/utils/paths.hpp
@@ -6,7 +6,7 @@
 
 namespace gamecoe {
     // Gets the executable directory (build root) full path
-    [[nodiscard]] std::expected<std::string, error> getExecutableDirectory();
+    [[nodiscard]] std::expected<std::string, error> executable_directory();
     // Gets relative path to build root, and returns the full path
-    [[nodiscard]] std::expected<std::string, error> resolvePath(const std::string &relativePath);
+    [[nodiscard]] std::expected<std::string, error> resolve_path(const std::string &relativePath);
 } // namespace gamecoe

--- a/include/gamecoe/utils/paths.hpp
+++ b/include/gamecoe/utils/paths.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <gamecoe/utils/error.hpp>
+#include <expected>
 #include <string>
 
 namespace gamecoe {
     // Gets the executable directory (build root) full path
-    std::string getExecutableDirectory();
+    [[nodiscard]] std::expected<std::string, error> getExecutableDirectory();
     // Gets relative path to build root, and returns the full path
-    std::string resolvePath(const std::string &relativePath);
+    [[nodiscard]] std::expected<std::string, error> resolvePath(const std::string &relativePath);
 } // namespace gamecoe

--- a/src/colorcoe.cpp
+++ b/src/colorcoe.cpp
@@ -56,9 +56,9 @@ namespace gamecoe
                         "Color::fromHex(): The string argument should be in format of \"#RRGGBBAA\" or \"#RRGGBB\" in hexadecimal"));
 
         auto parseHexDigit = [](char c) -> std::expected<std::uint8_t, error> {
-            if ('0' <= c && c <= '9')       return c - '0';
-            else if ('A' <= c && c <= 'F')  return 10U + (c - 'A');
-            else if ('a' <= c && c <= 'f')  return 10U + (c - 'a');
+            if ('0' <= c && c <= '9')       return static_cast<std::uint8_t>(c - '0');
+            else if ('A' <= c && c <= 'F')  return static_cast<std::uint8_t>(10U + (c - 'A'));
+            else if ('a' <= c && c <= 'f')  return static_cast<std::uint8_t>(10U + (c - 'a'));
 
             return std::unexpected(
                     detail::invalid_argument(

--- a/src/colorcoe.cpp
+++ b/src/colorcoe.cpp
@@ -48,19 +48,23 @@ namespace gamecoe
         return Color(clamp(red), clamp(green), clamp(blue), clamp(alpha));
     }
 
-    Color Color::fromHex(const std::string &hex)
+    std::expected<Color, error> Color::fromHex(const std::string &hex)
     {
         if (!hex.starts_with('#') || (hex.length() != 7 && hex.length() != 9))
-            detail::invalidArgument("Color::fromHex(): The string argument should be in format of \"#RRGGBBAA\" or \"#RRGGBB\" in hexadecimal");
+            return std::unexpected(
+                    detail::invalid_argument(
+                        "Color::fromHex(): The string argument should be in format of \"#RRGGBBAA\" or \"#RRGGBB\" in hexadecimal"));
 
-        auto parseHexDigit = [](char c) -> std::uint8_t {
+        auto parseHexDigit = [](char c) -> std::expected<std::uint8_t, error> {
             if ('0' <= c && c <= '9')       return c - '0';
             else if ('A' <= c && c <= 'F')  return 10U + (c - 'A');
             else if ('a' <= c && c <= 'f')  return 10U + (c - 'a');
 
-            detail::invalidArgument("Color::fromHex(): The string argument should be in format of \"#RRGGBBAA\" or \"#RRGGBB\" in hexadecimal");
+            return std::unexpected(
+                    detail::invalid_argument(
+                        "Color::fromHex(): The string argument should be in format of \"#RRGGBBAA\" or \"#RRGGBB\" in hexadecimal"));
         };
-        
+
         std::uint8_t values[4] = { 0U, 0U, 0U, 255U };
         std::size_t iterations = (hex.length() - 1) / 2; // 3 or 4
         for(std::size_t i = 0; i < iterations; ++i)
@@ -68,7 +72,13 @@ namespace gamecoe
             char first = hex[(2 * i) + 1];
             char second = hex[(2 * i) + 2];
 
-            values[i] = (parseHexDigit(first) << 4) | parseHexDigit(second);
+            auto firstResult = parseHexDigit(first);
+            if (!firstResult) return std::unexpected(firstResult.error());
+
+            auto secondResult = parseHexDigit(second);
+            if (!secondResult) return std::unexpected(secondResult.error());
+
+            values[i] = (firstResult.value() << 4) | secondResult.value();
         }
 
         return Color(values[0], values[1], values[2], values[3]);

--- a/src/gamecoe/utils/error_handler.cpp
+++ b/src/gamecoe/utils/error_handler.cpp
@@ -2,23 +2,30 @@
 #include <gamecoe_config.hpp>
 
 #if GAMECOE_USE_OPENGL
-#include <glad/gl.h>
+    #include <glad/gl.h>
 #endif
 
 namespace gamecoe
 {
     namespace detail
     {
-        void checkAndThrowError(const std::string &method)
+        error make_error(error_code code, const std::string &message)
         {
-#if GAMECOE_USE_OPENGL
-            GLenum error = glGetError();
-            if(error != GL_NO_ERROR) 
-                throwError(method + " OpenGL error: " + std::to_string(error));
-#endif
+            logcoe::error(message);
+            return error{code, message};
         }
 
-        void clearError()
+        std::expected<void, error> check_error(const std::string &method)
+        {
+#if GAMECOE_USE_OPENGL
+            GLenum err = glGetError();
+            if(err != GL_NO_ERROR)
+                return std::unexpected(make_error(error_code::opengl_error, method + " OpenGL error: " + std::to_string(err)));
+#endif
+            return {};
+        }
+
+        void clear_error()
         {
 #if GAMECOE_USE_OPENGL
             glGetError();

--- a/src/gamecoe/utils/paths.cpp
+++ b/src/gamecoe/utils/paths.cpp
@@ -1,6 +1,7 @@
 #include <gamecoe/utils/paths.hpp>
+#include <gamecoe/utils/error_handler.hpp>
+#include <expected>
 #include <filesystem>
-#include <stdexcept>
 
 #ifdef _WIN32
     #include <windows.h>
@@ -12,41 +13,60 @@
 
 namespace gamecoe
 {
-    std::filesystem::path getExecutablePath()
+    namespace
     {
-        std::filesystem::path exe;
-#if _WIN32
-        char path[MAX_PATH];
-        DWORD result = GetModuleFileNameA(NULL, path, MAX_PATH);
-        if (result == 0 || result == MAX_PATH)
-            throw std::runtime_error("[gamecoe] Could not get the executable path on Windows");
-        exe = std::filesystem::path(path);
-#elif __APPLE__
-        char path[PATH_MAX];
-        std::uint32_t size = PATH_MAX;
-        if(_NSGetExecutablePath(path, &size))
-           throw std::runtime_error("[gamecoe] Could not get the executable path on MacOS");
-        exe = std::filesystem::path(path);
-#elif __linux__
-        try { exe = std::filesystem::canonical("/proc/self/exe"); }
-        catch(const std::filesystem::filesystem_error &e)
+        std::expected<std::filesystem::path, error> getExecutablePath()
         {
-            throw std::runtime_error("[gamecoe] Could not get the executable path on Linux: " + std::string(e.what()));
-        }
+            std::filesystem::path exe;
+#if _WIN32
+            char path[MAX_PATH];
+            DWORD result = GetModuleFileNameA(NULL, path, MAX_PATH);
+            if (result == 0 || result == MAX_PATH)
+                return std::unexpected(
+                        detail::make_error(
+                            error_code::path_resolution_failed,
+                            "[gamecoe] Could not get the executable path on Windows"));
+            exe = std::filesystem::path(path);
+#elif __APPLE__
+            char path[PATH_MAX];
+            std::uint32_t size = PATH_MAX;
+            if(_NSGetExecutablePath(path, &size))
+               return std::unexpected(
+                        detail::make_error(
+                            error_code::path_resolution_failed,
+                            "[gamecoe] Could not get the executable path on MacOS"));
+            exe = std::filesystem::path(path);
+#elif __linux__
+            try { exe = std::filesystem::canonical("/proc/self/exe"); }
+            catch(const std::filesystem::filesystem_error &e)
+            {
+                return std::unexpected(
+                            detail::make_error(
+                                error_code::path_resolution_failed,
+                                "[gamecoe] Could not get the executable path on Linux: " + std::string(e.what())));
+            }
 #else
-        throw std::runtime_error("[gamecoe] Unsupported Operation System");
+            return std::unexpected(
+                    detail::make_error(
+                        error_code::unsupported_platform,
+                        "[gamecoe] Unsupported Operation System"));
 #endif
 
-        return exe;
+            return exe;
+        }
     }
 
-    std::string getExecutableDirectory()
+    std::expected<std::string, error> getExecutableDirectory()
     {
-        return getExecutablePath().parent_path().string();
+        auto exe = getExecutablePath();
+        if (!exe) return std::unexpected(exe.error());
+        return exe->parent_path().string();
     }
 
-    std::string resolvePath(const std::string &relativePath)
+    std::expected<std::string, error> resolvePath(const std::string &relativePath)
     {
-        return (getExecutablePath().parent_path() / relativePath).string();
+        auto exe = getExecutablePath();
+        if (!exe) return std::unexpected(exe.error());
+        return (exe->parent_path() / relativePath).string();
     }
 } // namespace gamecoe

--- a/src/gamecoe/utils/paths.cpp
+++ b/src/gamecoe/utils/paths.cpp
@@ -56,14 +56,14 @@ namespace gamecoe
         }
     }
 
-    std::expected<std::string, error> getExecutableDirectory()
+    std::expected<std::string, error> executable_directory()
     {
         auto exe = getExecutablePath();
         if (!exe) return std::unexpected(exe.error());
         return exe->parent_path().string();
     }
 
-    std::expected<std::string, error> resolvePath(const std::string &relativePath)
+    std::expected<std::string, error> resolve_path(const std::string &relativePath)
     {
         auto exe = getExecutablePath();
         if (!exe) return std::unexpected(exe.error());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(gamecoe_tests
     main.cpp
+    colorcoe_tests.cpp
     entity/entity_tests.cpp
     entity/sparse_set_tests.cpp
     entity/component_pool_tests.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(gamecoe_tests
     main.cpp
     colorcoe_tests.cpp
+    utils/paths_tests.cpp
     entity/entity_tests.cpp
     entity/sparse_set_tests.cpp
     entity/component_pool_tests.cpp

--- a/tests/colorcoe_tests.cpp
+++ b/tests/colorcoe_tests.cpp
@@ -8,10 +8,7 @@ using namespace gamecoe;
 //                 ColorcoeTests - Color::fromHex() tests
 //==============================================================================
 
-class ColorcoeTests : public ::testing::Test
-{
-protected:
-};
+class ColorcoeTests : public ::testing::Test { };
 
 //==============================================================================
 //                         Successful Decoding

--- a/tests/colorcoe_tests.cpp
+++ b/tests/colorcoe_tests.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+#include <colorcoe.hpp>
+#include <gamecoe/utils/error.hpp>
+
+using namespace gamecoe;
+
+//==============================================================================
+//                 ColorcoeTests - Color::fromHex() tests
+//==============================================================================
+
+class ColorcoeTests : public ::testing::Test
+{
+protected:
+};
+
+//==============================================================================
+//                         Successful Decoding
+//==============================================================================
+
+TEST_F(ColorcoeTests, FromHexSuccess)
+{
+    // Test 1: "#RRGGBB" decodes red/green/blue with the default alpha
+    {
+        auto result = Color::fromHex("#6C5CE8");
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result->red(), 0x6C);
+        EXPECT_EQ(result->green(), 0x5C);
+        EXPECT_EQ(result->blue(), 0xE8);
+        EXPECT_EQ(result->alpha(), 255);
+        EXPECT_EQ(result.value(), Color(0x6C, 0x5C, 0xE8));
+    }
+
+    // Test 2: "#RRGGBBAA" decodes red/green/blue/alpha exactly
+    {
+        auto result = Color::fromHex("#1A2B3C4D");
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result->red(), 0x1A);
+        EXPECT_EQ(result->green(), 0x2B);
+        EXPECT_EQ(result->blue(), 0x3C);
+        EXPECT_EQ(result->alpha(), 0x4D);
+        EXPECT_EQ(result.value(), Color(0x1A, 0x2B, 0x3C, 0x4D));
+    }
+}
+
+//==============================================================================
+//                          Malformed Input Failures
+//==============================================================================
+
+TEST_F(ColorcoeTests, FromHexFailure)
+{
+    // Test 1: missing the leading '#'
+    {
+        auto result = Color::fromHex("6C5CE8");
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code, error_code::invalid_argument);
+    }
+
+    // Test 2: wrong length
+    {
+        auto result = Color::fromHex("#6C5");
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code, error_code::invalid_argument);
+    }
+
+    // Test 3: non-hex digit among otherwise valid-length input
+    {
+        auto result = Color::fromHex("#GG5CE8");
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code, error_code::invalid_argument);
+    }
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -12,6 +12,7 @@ int printHelp()
     std::cout << "  --test=SUITE.TEST Run only the specified test" << std::endl;
     std::cout << std::endl;
     std::cout << "Available test suites:" << std::endl;
+    std::cout << "  ColorcoeTests            - Color hex decoding tests" << std::endl;
     std::cout << "  EntityTests              - Entity handle tests" << std::endl;
     std::cout << "  SparseSetTests           - Sparse set data structure tests" << std::endl;
     std::cout << "  ComponentPoolTests       - Component pool wrapper tests" << std::endl;

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -13,6 +13,7 @@ int printHelp()
     std::cout << std::endl;
     std::cout << "Available test suites:" << std::endl;
     std::cout << "  ColorcoeTests            - Color hex decoding tests" << std::endl;
+    std::cout << "  PathsTests               - Executable path resolution tests" << std::endl;
     std::cout << "  EntityTests              - Entity handle tests" << std::endl;
     std::cout << "  SparseSetTests           - Sparse set data structure tests" << std::endl;
     std::cout << "  ComponentPoolTests       - Component pool wrapper tests" << std::endl;

--- a/tests/utils/paths_tests.cpp
+++ b/tests/utils/paths_tests.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+#include <gamecoe/utils/paths.hpp>
+#include <filesystem>
+
+using namespace gamecoe;
+
+//==============================================================================
+//                 PathsTests - Executable path resolution tests
+//==============================================================================
+
+class PathsTests : public ::testing::Test { };
+
+//==============================================================================
+//                           Successful Path Resolution
+//==============================================================================
+
+TEST_F(PathsTests, SuccessPaths)
+{
+    // Note: Failure-path tests (OS-call failures, unsupported platforms) are not
+    // deterministically triggerable from unit tests without mock seams; these are
+    // syscall-level or compile-time platform arms, not testable in a portable manner.
+
+    // Test 1: getExecutableDirectory() returns an existing directory
+    {
+        auto result = getExecutableDirectory();
+        ASSERT_TRUE(result.has_value());
+        std::string execDir = result.value();
+        EXPECT_TRUE(std::filesystem::exists(execDir));
+        EXPECT_TRUE(std::filesystem::is_directory(execDir));
+    }
+
+    // Test 2: resolvePath() returns the executable directory joined with the relative path
+    {
+        std::string relativePath = "some_relative_file";
+        auto result = resolvePath(relativePath);
+        ASSERT_TRUE(result.has_value());
+
+        auto execDirResult = getExecutableDirectory();
+        ASSERT_TRUE(execDirResult.has_value());
+
+        std::string expected = (std::filesystem::path(execDirResult.value()) / relativePath).string();
+        EXPECT_EQ(result.value(), expected);
+    }
+}

--- a/tests/utils/paths_tests.cpp
+++ b/tests/utils/paths_tests.cpp
@@ -20,22 +20,22 @@ TEST_F(PathsTests, SuccessPaths)
     // deterministically triggerable from unit tests without mock seams; these are
     // syscall-level or compile-time platform arms, not testable in a portable manner.
 
-    // Test 1: getExecutableDirectory() returns an existing directory
+    // Test 1: executable_directory() returns an existing directory
     {
-        auto result = getExecutableDirectory();
+        auto result = executable_directory();
         ASSERT_TRUE(result.has_value());
         std::string execDir = result.value();
         EXPECT_TRUE(std::filesystem::exists(execDir));
         EXPECT_TRUE(std::filesystem::is_directory(execDir));
     }
 
-    // Test 2: resolvePath() returns the executable directory joined with the relative path
+    // Test 2: resolve_path() returns the executable directory joined with the relative path
     {
         std::string relativePath = "some_relative_file";
-        auto result = resolvePath(relativePath);
+        auto result = resolve_path(relativePath);
         ASSERT_TRUE(result.has_value());
 
-        auto execDirResult = getExecutableDirectory();
+        auto execDirResult = executable_directory();
         ASSERT_TRUE(execDirResult.has_value());
 
         std::string expected = (std::filesystem::path(execDirResult.value()) / relativePath).string();


### PR DESCRIPTION
Color::fromHex(), the OpenGL error check, and the executable-path lookup all threw on failure.
This PR converts them to return std::expected from [[nodiscard]] factory functions instead.

- Add the gamecoe::error/error_code vocabulary type
- Add detail::make_error() to centralize error logging
- Rename and convert check_error()/clear_error() to std::expected
- Convert Color::fromHex() to std::expected
- Rename and convert executable_directory()/resolve_path() to std::expected
- Add ColorcoeTests and PathsTests
- Build the Linux Clang CI job against libc++ instead of libstdc++ for std::expected